### PR TITLE
Adding meta file for acknowledgements

### DIFF
--- a/InfoAcknowledgements.md.meta
+++ b/InfoAcknowledgements.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 2f8589f0105d84bb68081128d504f487
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Re: #19 

Adding meta file to to package to avoid `Asset Packages/com.unity.robotics.urdf-importer/InfoAcknowledgements.md has no meta file, but it's in an immutable folder. The asset will be ignored.` error.