### PR TITLE
AIRO- 412 Joint Position API correction

### DIFF
--- a/Runtime/UrdfComponents/UrdfJoints/UrdfJointContinuous.cs
+++ b/Runtime/UrdfComponents/UrdfJoints/UrdfJointContinuous.cs
@@ -44,7 +44,7 @@ namespace RosSharp.Urdf
 #if UNITY_2020_1_OR_NEWER
             return unityJoint.jointPosition[xAxis];
 #else
-                return -((HingeJoint)unityJoint).angle * Mathf.Deg2Rad;
+                return -((HingeJoint)unityJoint).angle;
 #endif
         }
 
@@ -57,7 +57,7 @@ namespace RosSharp.Urdf
             #if UNITY_2020_1_OR_NEWER
                 return unityJoint.velocity[xAxis];
             #else
-            return -((HingeJoint)unityJoint).velocity * Mathf.Deg2Rad;
+            return -((HingeJoint)unityJoint).velocity;
             #endif
         }
 

--- a/Runtime/UrdfComponents/UrdfJoints/UrdfJointRevolute.cs
+++ b/Runtime/UrdfComponents/UrdfJoints/UrdfJointRevolute.cs
@@ -47,7 +47,7 @@ namespace RosSharp.Urdf
         public override float GetPosition()
         {
             #if UNITY_2020_1_OR_NEWER
-            return ((ArticulationBody)unityJoint).jointPosition[xAxis] * Mathf.Deg2Rad;
+            return ((ArticulationBody)unityJoint).jointPosition[xAxis];
 #else
                         return -((HingeJoint)unityJoint).angle * Mathf.Deg2Rad;
 #endif
@@ -60,7 +60,7 @@ namespace RosSharp.Urdf
         public override float GetVelocity()
         {
             #if UNITY_2020_1_OR_NEWER
-                return ((ArticulationBody)unityJoint).jointVelocity[xAxis] * Mathf.Deg2Rad;
+                return ((ArticulationBody)unityJoint).jointVelocity[xAxis];
             #else
                         return -((HingeJoint)unityJoint).velocity * Mathf.Deg2Rad;
             #endif


### PR DESCRIPTION
Remove an extra multiplication factor when returning joint position and velocity using URDF importer. Originally intended as a conversion from Deg to Rad. Articulation Body API later changed to radians.