### PR TITLE
Adding default values for Articulation Body Parameters

### DIFF
--- a/com.unity.robotics.urdf-importer/Editor/NeedsRuntimeConversion/Extensions/UrdfRobotExtensions.cs
+++ b/com.unity.robotics.urdf-importer/Editor/NeedsRuntimeConversion/Extensions/UrdfRobotExtensions.cs
@@ -47,12 +47,11 @@ namespace RosSharp.Urdf.Editor
 
         #region Import
 
-        public static IEnumerator Create(string filename, ImportSettings settings, bool loadStatus = false)
+        public static IEnumerator<GameObject> Create(string filename, ImportSettings settings, bool loadStatus = false)
         {
             CreateTag();
             importsettings = settings;
             Robot robot = new Robot(filename);
-
             settings.totalLinks = robot.links.Count;
 
             if (!UrdfAssetPathHandler.IsValidAssetPath(robot.filename))
@@ -98,6 +97,8 @@ namespace RosSharp.Urdf.Editor
 
             CorrectAxis(robotGameObject);
             CreateCollisionExceptions(robot, robotGameObject);
+
+            yield return robotGameObject;
         }
 
         public static void CorrectAxis(GameObject robot)

--- a/com.unity.robotics.urdf-importer/Runtime/UrdfComponents/UrdfInertial.cs
+++ b/com.unity.robotics.urdf-importer/Runtime/UrdfComponents/UrdfInertial.cs
@@ -34,6 +34,7 @@ namespace RosSharp.Urdf
 
         private const int RoundDigits = 10;
         private const float MinInertia = 1e-6f;
+        private const float minMass = 0.1;
 
         public static void Create(GameObject linkObject, Link.Inertial inertial = null)
         {
@@ -46,7 +47,7 @@ namespace RosSharp.Urdf
 #endif
             if (inertial != null)
             {
-                robotLink.mass = ((float)inertial.mass > 0)?((float)inertial.mass):(float)0.1;
+                robotLink.mass = ((float)inertial.mass > 0)?((float)inertial.mass):minMass;
                 if (inertial.origin != null) {
                     
                     robotLink.centerOfMass = UrdfOrigin.GetPositionFromUrdf(inertial.origin);

--- a/com.unity.robotics.urdf-importer/Runtime/UrdfComponents/UrdfInertial.cs
+++ b/com.unity.robotics.urdf-importer/Runtime/UrdfComponents/UrdfInertial.cs
@@ -34,7 +34,7 @@ namespace RosSharp.Urdf
 
         private const int RoundDigits = 10;
         private const float MinInertia = 1e-6f;
-        private const float minMass = 0.1;
+        private const float minMass = 0.1f;
 
         public static void Create(GameObject linkObject, Link.Inertial inertial = null)
         {

--- a/com.unity.robotics.urdf-importer/Runtime/UrdfComponents/UrdfInertial.cs
+++ b/com.unity.robotics.urdf-importer/Runtime/UrdfComponents/UrdfInertial.cs
@@ -46,7 +46,7 @@ namespace RosSharp.Urdf
 #endif
             if (inertial != null)
             {
-                robotLink.mass = ((float)inertial.mass > 0)?((float)inertial.mass):0.1;
+                robotLink.mass = ((float)inertial.mass > 0)?((float)inertial.mass):(float)0.1;
                 if (inertial.origin != null) {
                     
                     robotLink.centerOfMass = UrdfOrigin.GetPositionFromUrdf(inertial.origin);

--- a/com.unity.robotics.urdf-importer/Runtime/UrdfComponents/UrdfInertial.cs
+++ b/com.unity.robotics.urdf-importer/Runtime/UrdfComponents/UrdfInertial.cs
@@ -46,7 +46,7 @@ namespace RosSharp.Urdf
 #endif
             if (inertial != null)
             {
-                robotLink.mass = (float)inertial.mass;
+                robotLink.mass = ((float)inertial.mass > 0)?((float)inertial.mass):0.1;
                 if (inertial.origin != null) {
                     
                     robotLink.centerOfMass = UrdfOrigin.GetPositionFromUrdf(inertial.origin);

--- a/com.unity.robotics.urdf-importer/Runtime/UrdfComponents/UrdfJoints/UrdfJoint.cs
+++ b/com.unity.robotics.urdf-importer/Runtime/UrdfComponents/UrdfJoints/UrdfJoint.cs
@@ -52,6 +52,9 @@ namespace RosSharp.Urdf
         protected const int RoundDigits = 6;
         protected const float Tolerance = 0.0000001f;
 
+        protected int defaultDamping = 0;
+        protected int defaultFriction = 0;
+
         public static void Create(GameObject linkObject, JointTypes jointType, Joint joint = null)
         { 
             #if UNITY_2020_1_OR_NEWER 

--- a/com.unity.robotics.urdf-importer/Runtime/UrdfComponents/UrdfJoints/UrdfJointContinuous.cs
+++ b/com.unity.robotics.urdf-importer/Runtime/UrdfComponents/UrdfJoints/UrdfJointContinuous.cs
@@ -101,8 +101,8 @@ namespace RosSharp.Urdf
 
             if (joint.dynamics != null)
             {
-                unityJoint.angularDamping = (double.IsNaN(joint.dynamics.damping)) ? 0 : (float)joint.dynamics.damping;
-                unityJoint.jointFriction = (double.IsNaN(joint.dynamics.friction)) ? 0 : (float)joint.dynamics.friction;
+                unityJoint.angularDamping = (double.IsNaN(joint.dynamics.damping)) ? defaultDamping : (float)joint.dynamics.damping;
+                unityJoint.jointFriction = (double.IsNaN(joint.dynamics.friction)) ? defaultFriction : (float)joint.dynamics.friction;
             }
             else
             {

--- a/com.unity.robotics.urdf-importer/Runtime/UrdfComponents/UrdfJoints/UrdfJointContinuous.cs
+++ b/com.unity.robotics.urdf-importer/Runtime/UrdfComponents/UrdfJoints/UrdfJointContinuous.cs
@@ -101,8 +101,8 @@ namespace RosSharp.Urdf
 
             if (joint.dynamics != null)
             {
-                unityJoint.angularDamping = (float)joint.dynamics.damping; 
-                unityJoint.jointFriction = (float)joint.dynamics.friction;
+                unityJoint.angularDamping = (double.IsNaN(joint.dynamics.damping)) ? 0 : (float)joint.dynamics.damping;
+                unityJoint.jointFriction = (double.IsNaN(joint.dynamics.friction)) ? 0 : (float)joint.dynamics.friction;
             }
             else
             {

--- a/com.unity.robotics.urdf-importer/Runtime/UrdfComponents/UrdfJoints/UrdfJointFixed.cs
+++ b/com.unity.robotics.urdf-importer/Runtime/UrdfComponents/UrdfJoints/UrdfJointFixed.cs
@@ -24,7 +24,7 @@ namespace RosSharp.Urdf
         {
             UrdfJointFixed urdfJoint = linkObject.AddComponent<UrdfJointFixed>();
             #if UNITY_2020_1_OR_NEWER
-                urdfJoint.unityJoint = linkObject.AddComponent<ArticulationBody>();
+                urdfJoint.unityJoint = linkObject.GetComponent<ArticulationBody>();
             #else
                         urdfJoint.UnityJoint = linkObject.AddComponent<FixedJoint>();
                         urdfJoint.UnityJoint.autoConfigureConnectedAnchor = true;

--- a/com.unity.robotics.urdf-importer/Runtime/UrdfComponents/UrdfJoints/UrdfJointPrismatic.cs
+++ b/com.unity.robotics.urdf-importer/Runtime/UrdfComponents/UrdfJoints/UrdfJointPrismatic.cs
@@ -31,7 +31,6 @@ namespace RosSharp.Urdf
         {
             UrdfJointPrismatic urdfJoint = linkObject.AddComponent<UrdfJointPrismatic>();
 #if UNITY_2020_1_OR_NEWER
-            linkObject.AddComponent<ArticulationBody>();
             urdfJoint.unityJoint = linkObject.GetComponent<ArticulationBody>();
             urdfJoint.unityJoint.jointType = ArticulationJointType.PrismaticJoint;
 #else
@@ -116,32 +115,17 @@ namespace RosSharp.Urdf
 
         protected override void ImportJointData(Joint joint)
         {
-#if UNITY_2020_1_OR_NEWER
             AdjustMovement(joint);
-
             if (joint.dynamics != null)
             {
-                unityJoint.linearDamping = (float)joint.dynamics.damping;
-                unityJoint.jointFriction = (float)joint.dynamics.friction;
+                unityJoint.angularDamping = (double.IsNaN(joint.dynamics.damping)) ? 0 : (float)joint.dynamics.damping;
+                unityJoint.jointFriction = (double.IsNaN(joint.dynamics.friction)) ? 0 : (float)joint.dynamics.friction;
             }
             else
             {
                 unityJoint.angularDamping = 0;
                 unityJoint.jointFriction = 0;
             }
-#else
-            ArticulationBody prismaticJoint = (ArticulationBody) unityJoint;
-            prismaticJoint.axis = (joint.axis != null) ? GetAxis(joint.axis) : GetDefaultAxis();
-
-            if (joint.dynamics != null)
-                prismaticJoint.xDrive = GetJointDrive(joint.dynamics);
-
-            if (joint.limit != null)
-            {
-                PrismaticJointLimitsManager prismaticLimits = GetComponent<PrismaticJointLimitsManager>();
-                prismaticLimits.InitializeLimits(joint.limit);
-            }
-#endif
         }
 
         /// <summary>

--- a/com.unity.robotics.urdf-importer/Runtime/UrdfComponents/UrdfJoints/UrdfJointPrismatic.cs
+++ b/com.unity.robotics.urdf-importer/Runtime/UrdfComponents/UrdfJoints/UrdfJointPrismatic.cs
@@ -118,8 +118,8 @@ namespace RosSharp.Urdf
             AdjustMovement(joint);
             if (joint.dynamics != null)
             {
-                unityJoint.angularDamping = (double.IsNaN(joint.dynamics.damping)) ? 0 : (float)joint.dynamics.damping;
-                unityJoint.jointFriction = (double.IsNaN(joint.dynamics.friction)) ? 0 : (float)joint.dynamics.friction;
+                unityJoint.angularDamping = (double.IsNaN(joint.dynamics.damping)) ? defaultDamping : (float)joint.dynamics.damping;
+                unityJoint.jointFriction = (double.IsNaN(joint.dynamics.friction)) ? defaultFriction : (float)joint.dynamics.friction;
             }
             else
             {

--- a/com.unity.robotics.urdf-importer/Runtime/UrdfComponents/UrdfJoints/UrdfJointRevolute.cs
+++ b/com.unity.robotics.urdf-importer/Runtime/UrdfComponents/UrdfJoints/UrdfJointRevolute.cs
@@ -100,27 +100,17 @@ namespace RosSharp.Urdf
 
         protected override void ImportJointData(Joint joint)
         {
-#if UNITY_2020_1_OR_NEWER
             AdjustMovement(joint);
             if (joint.dynamics != null)
             {
-                unityJoint.angularDamping = (float)joint.dynamics.damping; 
-                unityJoint.jointFriction = (float)joint.dynamics.friction;
+                unityJoint.angularDamping = (double.IsNaN(joint.dynamics.damping)) ? 0 : (float)joint.dynamics.damping;
+                unityJoint.jointFriction = (double.IsNaN(joint.dynamics.friction)) ? 0 : (float)joint.dynamics.friction;
             }
             else
             {
                 unityJoint.angularDamping = 0;
                 unityJoint.jointFriction = 0;
             }
-#else
-                        unityJoint.axis = (joint.axis != null) ? GetAxis(joint.axis) : GetDefaultAxis();
-
-                        if (joint.dynamics != null)
-                            ((HingeJoint)unityJoint).spring = GetJointSpring(joint.dynamics);
-
-                        if (joint.limit != null)
-                            GetComponent<HingeJointLimitsManager>().InitializeLimits(joint.limit, (HingeJoint)unityJoint);
-#endif
         }
 
         protected override Joint ExportSpecificJointData(Joint joint)

--- a/com.unity.robotics.urdf-importer/Runtime/UrdfComponents/UrdfJoints/UrdfJointRevolute.cs
+++ b/com.unity.robotics.urdf-importer/Runtime/UrdfComponents/UrdfJoints/UrdfJointRevolute.cs
@@ -103,8 +103,8 @@ namespace RosSharp.Urdf
             AdjustMovement(joint);
             if (joint.dynamics != null)
             {
-                unityJoint.angularDamping = (double.IsNaN(joint.dynamics.damping)) ? 0 : (float)joint.dynamics.damping;
-                unityJoint.jointFriction = (double.IsNaN(joint.dynamics.friction)) ? 0 : (float)joint.dynamics.friction;
+                unityJoint.angularDamping = (double.IsNaN(joint.dynamics.damping)) ? defaultDamping : (float)joint.dynamics.damping;
+                unityJoint.jointFriction = (double.IsNaN(joint.dynamics.friction)) ? defaultFriction : (float)joint.dynamics.friction;
             }
             else
             {


### PR DESCRIPTION
If a mass of the link is zero, a default value is added. This is done for stability in physics Engine as it doesn't support zero mass values.