### PR TITLE
Replace ../ with package://, throw more warnings otherwise

### DIFF
--- a/com.unity.robotics.urdf-importer/Runtime/AssetHandlers/UrdfAssetPathHandler.cs
+++ b/com.unity.robotics.urdf-importer/Runtime/AssetHandlers/UrdfAssetPathHandler.cs
@@ -74,11 +74,19 @@ namespace RosSharp.Urdf
 
         public static string GetRelativeAssetPathFromUrdfPath(string urdfPath, bool convertToPrefab=true)
         {
-            //if (!urdfPath.StartsWith(@"package://"))
-            //{
-            //    Debug.LogWarning(urdfPath + " is not a valid URDF package file path. Path should start with \"package://\".");
-            //    return null;
-            //}
+            if (!urdfPath.StartsWith(@"package://"))
+            {
+               Debug.LogWarning(urdfPath + " is not a valid URDF package file path. Path should start with \"package://\", and URDF file should be in the directory root.");
+               if (urdfPath.Substring(0, 3) == "../")
+               {
+                   Debug.LogWarning("Attempting to replace starting instance of `../` with `package://`.");
+                   urdfPath = $@"package://{urdfPath.Substring(3)}";
+               }
+               else
+               {
+                   return null;
+               }
+            }
             string path;
             if (urdfPath.StartsWith(@"package://"))
             {


### PR DESCRIPTION
## Proposed change(s)

Replace starting `../` with `package://` in filename parsing for URDF import, and print more warning messages if this does not work.

### Useful links (GitHub issues, JIRA tickets, forum threads, etc.)

- [AIRO-570](https://jira.unity3d.com/browse/AIRO-570)
- [Asset not found issue](https://github.com/Unity-Technologies/URDF-Importer/issues/69)

### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update
- [ ] Other (please describe)

## Testing and Verification

Ran existing unit tests to verify build/player didn't break, also used Pick-and-Place project to import Niryo One and user's modified directory structure (but unmodified urdf file) from [this issue](https://github.com/Unity-Technologies/URDF-Importer/issues/69#issuecomment-832095528). 

### Test Configuration:
- Unity Version: 2020.2.0b9
- Unity machine OS + version: Mac OS 10.15.7

## Checklist
- [x] Ensured this PR is up-to-date with the `dev` branch
- [x] Created this PR to target the `dev` branch
- [x] Followed the style guidelines as described in the [Contribution Guidelines](../CONTRIBUTING.md)
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the documentation as appropriate