### PR TITLE
Refuse to convert stls in Packages because the directory may be immutable

### DIFF
--- a/com.unity.robotics.urdf-importer/CHANGELOG.md
+++ b/com.unity.robotics.urdf-importer/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 ### Removed
 
 ### Fixed
+ - Bug where-in URDF Importer would throw an error when installed via Package Manager because it can't save prefabs to its own directories 
 
 
 ## [0.4.0-preview] - 2021-05-27

--- a/com.unity.robotics.urdf-importer/Runtime/MeshProcessing/StlAssetPostProcessor.cs
+++ b/com.unity.robotics.urdf-importer/Runtime/MeshProcessing/StlAssetPostProcessor.cs
@@ -26,14 +26,27 @@ namespace RosSharp
     public class StlAssetPostProcessor
 #endif    
     {
-        private static void OnPostprocessAllAssets(string[] importedAssets, string[] deletedAssets, string[] movedAssets, string[] movedFromPath)
+        static void OnPostprocessAllAssets(string[] importedAssets, string[] deletedAssets, string[] movedAssets, string[] movedFromPath)
         {
 #if UNITY_EDITOR
             if (!RuntimeURDF.IsRuntimeMode())
             {
-                foreach (string stlFile in importedAssets.Where(x => x.ToLowerInvariant().EndsWith(".stl")))
+                foreach (var stlFile in importedAssets.Where(x => x.ToLowerInvariant().EndsWith(".stl")))
                 {
-                    createStlPrefab(stlFile);
+                    if (stlFile.StartsWith("Assets"))
+                    {
+                        Debug.Log($"Detected an stl file at {stlFile} - creating a mesh prefab.");
+                        createStlPrefab(stlFile);
+                    }
+                    else if (stlFile.StartsWith("Packages"))
+                    {
+                        Debug.Log($"Found an stl file at {stlFile} - ignoring because it's a Package asset");
+                    }
+                    else
+                    {
+                        Debug.LogWarning($"Found an stl file at {stlFile} - " + 
+                            "ignoring because we don't know how to handle an asset in this location.");
+                    }
                 }
             }
 #endif

--- a/com.unity.robotics.urdf-importer/Runtime/MeshProcessing/StlAssetPostProcessor.cs
+++ b/com.unity.robotics.urdf-importer/Runtime/MeshProcessing/StlAssetPostProcessor.cs
@@ -33,19 +33,21 @@ namespace RosSharp
             {
                 foreach (var stlFile in importedAssets.Where(x => x.ToLowerInvariant().EndsWith(".stl")))
                 {
-                    if (stlFile.StartsWith("Assets"))
+                    var stlFileLowercase = stlFile.ToLower();
+                    if (stlFileLowercase.StartsWith("assets"))
                     {
                         Debug.Log($"Detected an stl file at {stlFile} - creating a mesh prefab.");
                         createStlPrefab(stlFile);
                     }
-                    else if (stlFile.StartsWith("Packages"))
+                    else if (stlFileLowercase.StartsWith("packages"))
                     {
-                        Debug.Log($"Found an stl file at {stlFile} - ignoring because it's a Package asset");
+                        Debug.Log($"Found an stl file at {stlFile} - " + 
+                            "skipping post-processing because it's a Package asset");
                     }
                     else
                     {
                         Debug.LogWarning($"Found an stl file at {stlFile} - " + 
-                            "ignoring because we don't know how to handle an asset in this location.");
+                            "skipping post-processing because we don't know how to handle an asset in this location.");
                     }
                 }
             }

--- a/com.unity.robotics.urdf-importer/package.json
+++ b/com.unity.robotics.urdf-importer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.unity.robotics.urdf-importer",
-  "version": "0.4.0-preview",
+  "version": "0.4.1-preview",
   "displayName": "URDF Importer",
   "description": "Facilitates importing configurations from the Universal Robot Description Format",
   "unity": "2020.2",


### PR DESCRIPTION
## Proposed change(s)

PickAndPlace integration tests failed because on installing URDF Importer via the package manager, the stl file in the Tests folder is detected and processed which results in URDF importer attempting to save a prefab in a directory that can't be written to. 

Changed the logic in the asset post processing to ignore assets if they are not in the "Assets" folder (aka not a part of the currently open Project).

### Useful links (GitHub issues, JIRA tickets, forum threads, etc.)
https://unity-ci.cds.internal.unity3d.com/job/7107835

### Types of change(s)

- [x ] Bug fix

## Testing and Verification

Validated locally that package assets are ignored by copying new stls into different locations.

## Checklist
- [x ] Ensured this PR is up-to-date with the `dev` branch
- [x] Created this PR to target the `dev` branch
- [x] Followed the style guidelines as described in the [Contribution Guidelines](https://github.com/Unity-Technologies/URDF-Importer/blob/main/CONTRIBUTING.md)
- [x] (N/A) Added tests that prove my fix is effective or that my feature works 
- [x] Updated the [Changelog](https://github.com/Unity-Technologies/URDF-Importer/blob/dev/com.unity.robotics.urdf-importer/CHANGELOG.md) and described changes in the [Unreleased section](https://github.com/Unity-Technologies/URDF-Importer/blob/dev/com.unity.robotics.urdf-importer/CHANGELOG.md#unreleased)