### PR TITLE
Disable stl Postprocessing

### DIFF
--- a/com.unity.robotics.urdf-importer/CHANGELOG.md
+++ b/com.unity.robotics.urdf-importer/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 ### Added
 
 ### Changed
+ - STL files will not be automatically processed to create .prefab files when copied into the Assets directory or when assets are reimported. Instead the processing happens during the URDF import and required .prefab files will be created if they don't exist already or if the "Overwrite Existing Prefabs" option is checked in the URDF Import settings dialog.
 
 ### Deprecated
 
@@ -20,7 +21,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ### Fixed
  - Bug where-in URDF Importer would throw an error when installed via Package Manager because it can't save prefabs to its own directories 
-
 
 ## [0.4.0-preview] - 2021-05-27
 

--- a/com.unity.robotics.urdf-importer/Editor/MenuItems/FileImportMenu.cs
+++ b/com.unity.robotics.urdf-importer/Editor/MenuItems/FileImportMenu.cs
@@ -54,7 +54,7 @@ namespace Unity.Robotics.UrdfImporter.Editor
             EditorGUILayout.EndHorizontal();
 
             GUILayout.Space(10);
-            settings.overwriteExistingPrefabs = GUILayout.Toggle (settings.overwriteExistingPrefabs, "Overwrite Existing Prefabs");
+            settings.overwriteExistingPrefabs = GUILayout.Toggle(settings.overwriteExistingPrefabs, "Overwrite Existing Prefabs");
             
             //Import Robot button
             GUILayout.Space(10);

--- a/com.unity.robotics.urdf-importer/Editor/MenuItems/FileImportMenu.cs
+++ b/com.unity.robotics.urdf-importer/Editor/MenuItems/FileImportMenu.cs
@@ -53,6 +53,9 @@ namespace Unity.Robotics.UrdfImporter.Editor
                 "Mesh Decomposer", settings.convexMethod);
             EditorGUILayout.EndHorizontal();
 
+            GUILayout.Space(10);
+            settings.overwriteExistingPrefabs = GUILayout.Toggle (settings.overwriteExistingPrefabs, "Overwrite Existing Prefabs");
+            
             //Import Robot button
             GUILayout.Space(10);
             if (GUILayout.Button("Import URDF"))

--- a/com.unity.robotics.urdf-importer/Editor/MenuItems/FileImportMenu.cs
+++ b/com.unity.robotics.urdf-importer/Editor/MenuItems/FileImportMenu.cs
@@ -54,7 +54,7 @@ namespace Unity.Robotics.UrdfImporter.Editor
             EditorGUILayout.EndHorizontal();
 
             GUILayout.Space(10);
-            settings.overwriteExistingPrefabs = GUILayout.Toggle(settings.overwriteExistingPrefabs, "Overwrite Existing Prefabs");
+            settings.OverwriteExistingPrefabs = GUILayout.Toggle(settings.OverwriteExistingPrefabs, "Overwrite Existing Prefabs");
             
             //Import Robot button
             GUILayout.Space(10);

--- a/com.unity.robotics.urdf-importer/Runtime/AssetHandlers/LocateAssetHandler.cs
+++ b/com.unity.robotics.urdf-importer/Runtime/AssetHandlers/LocateAssetHandler.cs
@@ -28,7 +28,7 @@ namespace Unity.Robotics.UrdfImporter
             var originalUrdfPath = UrdfAssetPathHandler.GetRelativeAssetPathFromUrdfPath(urdfFileName, false);
             if (originalUrdfPath.ToLower().EndsWith(".stl"))
             {// it is an asset that requires post processing
-                if (UrdfRobotExtensions.importsettings.overwriteExistingPrefabs || !RuntimeURDF.AssetExists(fileAssetPath, true))
+                if (UrdfRobotExtensions.importsettings.OverwriteExistingPrefabs || !RuntimeURDF.AssetExists(fileAssetPath, true))
                 {// post process again to (re)create prefabs
                     StlAssetPostProcessor.PostprocessStlFile(originalUrdfPath);
                 }                

--- a/com.unity.robotics.urdf-importer/Runtime/AssetHandlers/LocateAssetHandler.cs
+++ b/com.unity.robotics.urdf-importer/Runtime/AssetHandlers/LocateAssetHandler.cs
@@ -28,7 +28,7 @@ namespace Unity.Robotics.UrdfImporter
             var originalUrdfPath = UrdfAssetPathHandler.GetRelativeAssetPathFromUrdfPath(urdfFileName, false);
             if (originalUrdfPath.ToLower().EndsWith(".stl"))
             {// it is an asset that requires post processing
-                if (UrdfRobotExtensions.importsettings.overwriteExistingPrefabs || !RuntimeURDF.AssetExists(fileAssetPath))
+                if (UrdfRobotExtensions.importsettings.overwriteExistingPrefabs || !RuntimeURDF.AssetExists(fileAssetPath, true))
                 {// post process again to (re)create prefabs
                     StlAssetPostProcessor.PostprocessStlFile(originalUrdfPath);
                 }                

--- a/com.unity.robotics.urdf-importer/Runtime/AssetHandlers/LocateAssetHandler.cs
+++ b/com.unity.robotics.urdf-importer/Runtime/AssetHandlers/LocateAssetHandler.cs
@@ -23,9 +23,20 @@ namespace Unity.Robotics.UrdfImporter
         public static T FindUrdfAsset<T>(string urdfFileName) where T : UnityEngine.Object
         {
             string fileAssetPath = UrdfAssetPathHandler.GetRelativeAssetPathFromUrdfPath(urdfFileName);
+
+            // check if it is an asset tha requires post processing (AIRO-908)
+            var originalUrdfPath = UrdfAssetPathHandler.GetRelativeAssetPathFromUrdfPath(urdfFileName, false);
+            if (originalUrdfPath.ToLower().EndsWith(".stl"))
+            {// it is an asset that requires post processing
+                if (UrdfRobotExtensions.importsettings.overwriteExistingPrefabs || !RuntimeURDF.AssetExists(fileAssetPath))
+                {// post process again to (re)create prefabs
+                    StlAssetPostProcessor.PostprocessStlFile(originalUrdfPath);
+                }                
+            }
+
             T assetObject = RuntimeURDF.AssetDatabase_LoadAssetAtPath<T>(fileAssetPath);
 
-            if (assetObject != null)
+            if (assetObject)
                 return assetObject;
 
             //If asset was not found, let user choose whether to search for

--- a/com.unity.robotics.urdf-importer/Runtime/MeshProcessing/StlAssetPostProcessor.cs
+++ b/com.unity.robotics.urdf-importer/Runtime/MeshProcessing/StlAssetPostProcessor.cs
@@ -26,6 +26,8 @@ namespace Unity.Robotics.UrdfImporter
     public class StlAssetPostProcessor
 #endif    
     {
+        private static Material s_DefaultDiffuse = null;
+        
         static void OnPostprocessAllAssets(string[] importedAssets, string[] deletedAssets, string[] movedAssets, string[] movedFromPath)
         {
             const bool enableStlPostprocessing = false; // AIRO-908 
@@ -73,7 +75,6 @@ namespace Unity.Robotics.UrdfImporter
             Object.DestroyImmediate(gameObject);
         }
 
-        private static Material s_DefaultDiffuse = null;
         private static Material GetDefaultDiffuseMaterial() 
         {
 #if UNITY_EDITOR

--- a/com.unity.robotics.urdf-importer/Runtime/MeshProcessing/StlAssetPostProcessor.cs
+++ b/com.unity.robotics.urdf-importer/Runtime/MeshProcessing/StlAssetPostProcessor.cs
@@ -18,29 +18,15 @@ using System.IO;
 
 namespace Unity.Robotics.UrdfImporter
 {
-    using Unity.Robotics;
-#if UNITY_EDITOR
-    using UnityEditor;
-    public class StlAssetPostProcessor : AssetPostprocessor
-#else
+    /// <summary>
+    /// Utility functions for processing STL mesh files.
+    /// Note that no post processing is done on STL files anymore when they are added to the project
+    /// As such StlAssetPostProcessor no longer drives from AssetPostProcessor and the OnPostprocessAllAssets()
+    /// function is removed. 
+    /// </summary>
     public class StlAssetPostProcessor
-#endif    
     {
         private static Material s_DefaultDiffuse = null;
-        
-        static void OnPostprocessAllAssets(string[] importedAssets, string[] deletedAssets, string[] movedAssets, string[] movedFromPath)
-        {
-            const bool enableStlPostprocessing = false; // AIRO-908 
-#if UNITY_EDITOR
-            if (!RuntimeURDF.IsRuntimeMode() && enableStlPostprocessing)
-            {
-                foreach (var stlFile in importedAssets.Where(x => x.ToLowerInvariant().EndsWith(".stl")))
-                {
-                    PostprocessStlFile(stlFile);
-                }
-            }
-#endif
-        }
 
         public static void PostprocessStlFile(string stlFile)
         {

--- a/com.unity.robotics.urdf-importer/Runtime/MeshProcessing/StlAssetPostProcessor.cs
+++ b/com.unity.robotics.urdf-importer/Runtime/MeshProcessing/StlAssetPostProcessor.cs
@@ -117,12 +117,12 @@ namespace Unity.Robotics.UrdfImporter
             return gameObject;
         }
         
-        private static string GetMeshAssetPath(string stlFile, int i)
+        public static string GetMeshAssetPath(string stlFile, int i)
         {
             return stlFile.Substring(0, stlFile.Length - 4) + "_" + i.ToString() + ".asset";
         }
 
-        private static string GetPrefabAssetPath(string stlFile)
+        public static string GetPrefabAssetPath(string stlFile)
         {
             return stlFile.Substring(0, stlFile.Length - 4) + ".prefab";
         }

--- a/com.unity.robotics.urdf-importer/Runtime/RuntimeImport/RuntimeURDF.cs
+++ b/com.unity.robotics.urdf-importer/Runtime/RuntimeImport/RuntimeURDF.cs
@@ -1,4 +1,5 @@
 using System;
+using System.IO;
 using UnityEngine;
 #if UNITY_EDITOR
 using UnityEditor;
@@ -233,4 +234,21 @@ public static class RuntimeURDF
         }
 #endif
     }
+    
+    public static bool AssetExists(string assetPath, bool ignoreCase = false)
+    {
+#if UNITY_EDITOR
+        string[] foldersToSearch = {Path.GetDirectoryName(assetPath)};
+        var assetName = Path.GetFileNameWithoutExtension(assetPath);
+        foreach (var guid2 in AssetDatabase_FindAssets(assetName, foldersToSearch))
+        {
+            var possiblePath = RuntimeURDF.AssetDatabase_GUIDToAssetPath(guid2);
+            if (string.Equals(possiblePath, assetPath, ignoreCase ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+#endif
+        return false;
+    }    
 }

--- a/com.unity.robotics.urdf-importer/Runtime/RuntimeImport/RuntimeURDFImporter.cs
+++ b/com.unity.robotics.urdf-importer/Runtime/RuntimeImport/RuntimeURDFImporter.cs
@@ -1,9 +1,7 @@
-using System;
 using System.Collections;
 using System.Collections.Generic;
 using Unity.Robotics.UrdfImporter;
 using Unity.Robotics.UrdfImporter.Control;
-using Unity.Robotics.UrdfImporter;
 using UnityEngine;
 
 /// <summary>

--- a/com.unity.robotics.urdf-importer/Runtime/UrdfComponents/ImportSettings.cs
+++ b/com.unity.robotics.urdf-importer/Runtime/UrdfComponents/ImportSettings.cs
@@ -21,7 +21,7 @@ namespace Unity.Robotics.UrdfImporter
         public axisType choosenAxis = axisType.yAxis;
         public convexDecomposer convexMethod = convexDecomposer.vHACD;
 
-        public bool overwriteExistingPrefabs { get; set; } = false;
+        public bool OverwriteExistingPrefabs { get; set; } = false;
 
         public int linksLoaded = 0;
         public int totalLinks = 0;

--- a/com.unity.robotics.urdf-importer/Runtime/UrdfComponents/ImportSettings.cs
+++ b/com.unity.robotics.urdf-importer/Runtime/UrdfComponents/ImportSettings.cs
@@ -21,6 +21,8 @@ namespace Unity.Robotics.UrdfImporter
         public axisType choosenAxis = axisType.yAxis;
         public convexDecomposer convexMethod = convexDecomposer.vHACD;
 
+        public bool overwriteExistingPrefabs { get; set; } = false;
+
         public int linksLoaded = 0;
         public int totalLinks = 0;
 

--- a/com.unity.robotics.urdf-importer/Tests/Editor/Unity.Robotics.URDFImporter.Editor.Tests.asmdef
+++ b/com.unity.robotics.urdf-importer/Tests/Editor/Unity.Robotics.URDFImporter.Editor.Tests.asmdef
@@ -4,7 +4,8 @@
     "references": [
         "UnityEngine.TestRunner",
         "UnityEditor.TestRunner",
-        "Unity.Robotics.UrdfImporter.Editor"
+        "Unity.Robotics.UrdfImporter.Editor",
+        "Unity.Robotics.UrdfImporter"
     ],
     "includePlatforms": [
         "Editor"

--- a/com.unity.robotics.urdf-importer/Tests/Runtime/MeshProcessing.meta
+++ b/com.unity.robotics.urdf-importer/Tests/Runtime/MeshProcessing.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 44e0aa47ef2dc4cbeb4d7fb17999a225
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.robotics.urdf-importer/Tests/Runtime/MeshProcessing/StlAssetPostProcessorTests.cs
+++ b/com.unity.robotics.urdf-importer/Tests/Runtime/MeshProcessing/StlAssetPostProcessorTests.cs
@@ -1,0 +1,51 @@
+using System.IO;
+using System.Collections.Generic;
+using NUnit.Framework;
+using UnityEditor;
+using UnityEngine;
+
+namespace Unity.Robotics.UrdfImporter.Tests
+{
+    public class StlAssetPostProcessorTests
+    {
+        const string k_AssetRoot = "Assets/Tests/Runtime/StlAssetPostProcessorTests";
+        const string k_StlCubeSourcePath = "Packages/com.unity.robotics.urdf-importer/Tests/Runtime/Assets/URDF/cube/meshes/cube.stl";//"Assets/meshes/cube.stl";
+        string m_StlCubeCopyPath;
+
+        [SetUp]
+        public void SetUp()
+        {
+            m_StlCubeCopyPath = k_AssetRoot + "/cube.stl";
+            RuntimeURDF.SetRuntimeMode(false);
+            Directory.CreateDirectory(k_AssetRoot);
+        }
+        
+        [Test]
+        public void StlPostprocess_NewStl_DontCreatePrefab()
+        {
+            // make a new copy of the stl file
+            Assert.IsTrue(AssetDatabase.CopyAsset(k_StlCubeSourcePath, m_StlCubeCopyPath));
+            Assert.IsTrue(RuntimeURDF.AssetExists(m_StlCubeCopyPath));
+
+            // make sure the .asset file is not automatically created
+            var meshAssetPath =  StlAssetPostProcessor.GetMeshAssetPath(m_StlCubeCopyPath, 0);            
+            Assert.IsFalse(RuntimeURDF.AssetExists(meshAssetPath));
+
+            // make sure the .prefab file is not automatically created
+            var prefabPath = StlAssetPostProcessor.GetPrefabAssetPath(m_StlCubeCopyPath);
+            Assert.IsFalse(RuntimeURDF.AssetExists(prefabPath));
+            
+            // make sure the .asset and .prefab file are created when requested
+            StlAssetPostProcessor.PostprocessStlFile(m_StlCubeCopyPath);
+            Assert.IsTrue(RuntimeURDF.AssetExists(meshAssetPath));
+            Assert.IsTrue(RuntimeURDF.AssetExists(prefabPath));
+        }
+        
+        [TearDown]
+        public void TearDown()
+        {
+            List<string> outFailedPaths = new List<string>();
+            AssetDatabase.DeleteAssets(new string[] {"Assets/Tests"}, outFailedPaths);
+        }
+    }
+}

--- a/com.unity.robotics.urdf-importer/Tests/Runtime/MeshProcessing/StlAssetPostProcessorTests.cs
+++ b/com.unity.robotics.urdf-importer/Tests/Runtime/MeshProcessing/StlAssetPostProcessorTests.cs
@@ -9,7 +9,7 @@ namespace Unity.Robotics.UrdfImporter.Tests
     public class StlAssetPostProcessorTests
     {
         const string k_AssetRoot = "Assets/Tests/Runtime/StlAssetPostProcessorTests";
-        const string k_StlCubeSourcePath = "Packages/com.unity.robotics.urdf-importer/Tests/Runtime/Assets/URDF/cube/meshes/cube.stl";//"Assets/meshes/cube.stl";
+        const string k_StlCubeSourcePath = "Packages/com.unity.robotics.urdf-importer/Tests/Runtime/Assets/URDF/cube/meshes/cube.stl";
         string m_StlCubeCopyPath;
 
         [SetUp]

--- a/com.unity.robotics.urdf-importer/Tests/Runtime/MeshProcessing/StlAssetPostProcessorTests.cs.meta
+++ b/com.unity.robotics.urdf-importer/Tests/Runtime/MeshProcessing/StlAssetPostProcessorTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0d226d856c98644969b886d1368d95d3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.robotics.urdf-importer/Tests/Runtime/RuntimeImport/RuntimeURDFTests.cs
+++ b/com.unity.robotics.urdf-importer/Tests/Runtime/RuntimeImport/RuntimeURDFTests.cs
@@ -150,6 +150,25 @@ namespace Unity.Robotics.UrdfImporter.Tests
             Assert.IsNotNull(RuntimeURDF.PrefabUtility_InstantiatePrefab(testObject));
         }
 
+        [Test]
+        public void AssetExists_True()
+        {
+            RuntimeURDF.SetRuntimeMode(false);
+            Assert.IsTrue(RuntimeURDF.AssetExists($"{createAssetPath}/TestAsset.prefab"));
+            Assert.IsTrue(RuntimeURDF.AssetExists($"{createAssetPath}/tEstAsset.Prefab", true));
+        }
+        
+        [Test]
+        public void AssetExists_False()
+        {
+            RuntimeURDF.SetRuntimeMode(false);
+            Assert.IsFalse(RuntimeURDF.AssetExists($"{createAssetPath}/tEstAsset.Prefab")); // case
+            Assert.IsFalse(RuntimeURDF.AssetExists($"{createAssetPath}/TestAsset.prefabs", true));
+            Assert.IsFalse(RuntimeURDF.AssetExists($"{createAssetPath}/TestAsset.prefa", true));
+            Assert.IsFalse(RuntimeURDF.AssetExists($"{createAssetPath}/estAsset.prefab", true));
+            Assert.IsFalse(RuntimeURDF.AssetExists($"{createAssetPath}/sub/TestAsset.prefab", true));
+        }
+        
         [TearDown]
         public void TearDown()
         {


### PR DESCRIPTION
## Proposed change(s)


Disabled the existing behaviour of URDF Importer overwriting existing assets in a Unity project. Instead:
- Not creating the assets for .stl meshes in the postprocess step any more
- Instead the assets will be created during URDF Import  if they don't exist already.
- A checkbox is added to the URDF Import UI to allow users to recreate the assets for STL files even if they already exist. 

### Useful links (GitHub issues, JIRA tickets, forum threads, etc.)
https://github.com/Unity-Technologies/URDF-Importer/issues/121
https://jira.unity3d.com/browse/AIRO-908


Provide any relevant links here.

### Types of change(s)

- [x] Bug fix
- [x] New feature
- [ ] Code refactor
- [ ] Documentation update
- [ ] Other (please describe)

## Testing and Verification


1. Copy a new URDF directory that includes .stl files into the asset folder: Note that no .asset or .prefab file will be created for the .stl mesh files.
1. From main menu select Assets > Reimport: Again note that no .asset or .prefab will be created
1. Import the URDF using the URDF Importer dialog:  The import should finish successfully
1. Note the modification date for the .prefab files created for the .stl mesh files. 
1. Reimport the URDF using the URDF Importer dialog with the "Overwrite Existing Prefabs" Option **un**checked: The .prefab files for the .stl mesh files should not have been modified.
1. Reimport the URDF using the URDF Importer dialog with the "Overwrite Existing Prefabs" Option checked: The .prefab files for the .stl mesh files should have been modified.


 Unit tests: 
- StlPostprocess_NewStl_DontCreatePrefab()
- AssetExists_False()
- AssetExists_True()

### Test Configuration:
- Unity Version: Unity 2020.3.13f1
- Unity machine OS + version: macOS Sierra 10.15.7

## Checklist
- [x] Ensured this PR is up-to-date with the `dev` branch
- [x] Created this PR to target the `dev` branch
- [x] Followed the style guidelines as described in the [Contribution Guidelines](https://github.com/Unity-Technologies/URDF-Importer/blob/main/CONTRIBUTING.md)
- [x] Added tests that prove my fix is effective or that my feature works
- [ ] Increased the [test coverage criteria](https://github.com/Unity-Technologies/URDF-Importer/blob/dev/.yamato/yamato-config.yml#L18) by 3%
- [x] Updated the [Changelog](https://github.com/Unity-Technologies/URDF-Importer/blob/dev/com.unity.robotics.urdf-importer/CHANGELOG.md) and described changes in the [Unreleased section](https://github.com/Unity-Technologies/URDF-Importer/blob/dev/com.unity.robotics.urdf-importer/CHANGELOG.md#unreleased)
- [ ] Updated the documentation as appropriate

## Other comments