### PR TITLE
fixing the compile error when creating a UWP build #122 (AIRO-920)

### DIFF
--- a/com.unity.robotics.urdf-importer/CHANGELOG.md
+++ b/com.unity.robotics.urdf-importer/CHANGELOG.md
@@ -19,7 +19,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 ### Removed
 
 ### Fixed
- - Bug where-in URDF Importer would throw an error when installed via Package Manager because it can't save prefabs to its own directories 
+ - Bug where-in URDF Importer would throw an error when installed via Package Manager because it can't save prefabs to its own directories
+ - Compile error "Plugin 'assimp.dll' is used from several locations" when creating a Universal Windows Platform build (#122) 
 
 
 ## [0.4.0-preview] - 2021-05-27

--- a/com.unity.robotics.urdf-importer/Runtime/UnityMeshImporter/Plugins/AssimpNet/Native/win/x86_64/assimp.dll.meta
+++ b/com.unity.robotics.urdf-importer/Runtime/UnityMeshImporter/Plugins/AssimpNet/Native/win/x86_64/assimp.dll.meta
@@ -23,6 +23,7 @@ PluginImporter:
         Exclude OSXUniversal: 0
         Exclude Win: 1
         Exclude Win64: 0
+        Exclude WindowsStoreApps: 0
   - first:
       Any: 
     second:
@@ -84,6 +85,16 @@ PluginImporter:
       enabled: 1
       settings:
         CPU: AnyCPU
+  - first:
+      Windows Store Apps: WindowsStoreApps
+    second:
+      enabled: 1
+      settings:
+        CPU: X64
+        DontProcess: false
+        PlaceholderPath: 
+        SDK: AnySDK
+        ScriptingBackend: AnyScriptingBackend
   userData: 
   assetBundleName: 
   assetBundleVariant: 


### PR DESCRIPTION
## Proposed change(s)

Modified the assembly definition configuration for the x86_64 version of the Assimpnet plugin to only be included in the x64 builds

### Useful links (GitHub issues, JIRA tickets, forum threads, etc.)

#122 
AIRO-920

### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update
- [ ] Other (please describe)

## Testing and Verification

Reproducing the issue requires installation of Universal Windows Platform development tools:

  -  Unity Editor on a Windows machine
  -  Windows 10 SDK: https://developer.microsoft.com/en-us/windows/downloads/windows-10-sdk/
  -  Universal Windows Platform development workload: https://docs.microsoft.com/en-us/visualstudio/get-started/csharp/tutorial-uwp?view=vs-2019
  -  Enable developer mode in settings: https://docs.microsoft.com/en-us/windows/apps/get-started/enable-your-device-for-development
  - Make sure you restart Unity after installing UWP components.


From build settings switch the platform to Universal Windows Platform and create new build. A build should be created without a compile issue.


### Test Configuration:
- Unity Version: [e.g. Unity 2020.3.13f1]
- Unity machine OS + version: Windows 10

## Checklist
- [x] Ensured this PR is up-to-date with the `dev` branch
- [x] Created this PR to target the `dev` branch
- [x] Followed the style guidelines as described in the [Contribution Guidelines](https://github.com/Unity-Technologies/URDF-Importer/blob/main/CONTRIBUTING.md)
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Increased the [test coverage criteria](https://github.com/Unity-Technologies/URDF-Importer/blob/dev/.yamato/yamato-config.yml#L18) by 3%
- [x] Updated the [Changelog](https://github.com/Unity-Technologies/URDF-Importer/blob/dev/com.unity.robotics.urdf-importer/CHANGELOG.md) and described changes in the [Unreleased section](https://github.com/Unity-Technologies/URDF-Importer/blob/dev/com.unity.robotics.urdf-importer/CHANGELOG.md#unreleased)
- [ ] Updated the documentation as appropriate

## Other comments
Even though this fixes the build issue, the URDF importer package will still not function in a UWP build due to a exception thrown when the scene has a game object with any component of URDF importer package ("A scripted object has a different serialization layout when loading"). The issue seem to be unrelated to issue #122 as it can be reproduced after removing Assimpnet plugin and even when using an older version of URDF importer before addition of Assimpnet plugin.