### PR TITLE
Multiple references to mesh fix

### DIFF
--- a/.yamato/yamato-config.yml
+++ b/.yamato/yamato-config.yml
@@ -15,7 +15,7 @@ commands:
     - command: |
         linecoverage=$(cat test-results/Report/Summary.xml | grep Linecoverage | grep -Eo '[+-]?[0-9]+([.][0-9]+)?')
         echo "Line coverage: $linecoverage%"
-        if (( $(echo "$linecoverage < 20" | bc -l) )); then exit 1; fi
+        if (( $(echo "$linecoverage < 35" | bc -l) )); then exit 1; fi
 triggers:
     cancel_old_ci: true
     expression: |

--- a/com.unity.robotics.urdf-importer/CHANGELOG.md
+++ b/com.unity.robotics.urdf-importer/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this repository will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+Fixed bug with multiple references to the same mesh during import
 
 ### Upgrade Notes
 

--- a/com.unity.robotics.urdf-importer/Editor/MenuItems/FileImportMenu.cs
+++ b/com.unity.robotics.urdf-importer/Editor/MenuItems/FileImportMenu.cs
@@ -63,7 +63,6 @@ namespace Unity.Robotics.UrdfImporter.Editor
                 if (urdfFile != "")
                 {
                     showLoadBar = true;
-                    UrdfGeometryCollision.CreatedAssetNames.Clear();
                     EditorCoroutineUtility.StartCoroutine(UrdfRobotExtensions.Create(urdfFile, settings,showLoadBar), this);
                 }
             }

--- a/com.unity.robotics.urdf-importer/Editor/MenuItems/FileImportMenu.cs
+++ b/com.unity.robotics.urdf-importer/Editor/MenuItems/FileImportMenu.cs
@@ -63,6 +63,7 @@ namespace Unity.Robotics.UrdfImporter.Editor
                 if (urdfFile != "")
                 {
                     showLoadBar = true;
+                    UrdfGeometryCollision.CreatedAssetNames.Clear();
                     EditorCoroutineUtility.StartCoroutine(UrdfRobotExtensions.Create(urdfFile, settings,showLoadBar), this);
                 }
             }

--- a/com.unity.robotics.urdf-importer/Runtime/AssetHandlers/LocateAssetHandler.cs
+++ b/com.unity.robotics.urdf-importer/Runtime/AssetHandlers/LocateAssetHandler.cs
@@ -28,7 +28,7 @@ namespace Unity.Robotics.UrdfImporter
             var originalUrdfPath = UrdfAssetPathHandler.GetRelativeAssetPathFromUrdfPath(urdfFileName, false);
             if (originalUrdfPath.ToLower().EndsWith(".stl"))
             {// it is an asset that requires post processing
-                if (UrdfRobotExtensions.importsettings.OverwriteExistingPrefabs || !RuntimeUrdf.AssetExists(fileAssetPath, true))
+                if ((UrdfRobotExtensions.importsettings.OverwriteExistingPrefabs || !RuntimeUrdf.AssetExists(fileAssetPath, true)) && !UrdfGeometryCollision.UsedTemplateFiles.Contains(Path.GetFileNameWithoutExtension(fileAssetPath)))
                 {// post process again to (re)create prefabs
                     StlAssetPostProcessor.PostprocessStlFile(originalUrdfPath);
                 }                

--- a/com.unity.robotics.urdf-importer/Runtime/Extensions/UrdfGeometryCollision.cs
+++ b/com.unity.robotics.urdf-importer/Runtime/Extensions/UrdfGeometryCollision.cs
@@ -21,7 +21,9 @@ namespace Unity.Robotics.UrdfImporter
 {
     public class UrdfGeometryCollision : UrdfGeometry
     {
-        public static List<string> CreatedAssetNames = new List<string>();
+        public static List<string> UsedTemplateFiles => s_UsedTemplateFiles;
+        static List<string> s_UsedTemplateFiles = new List<string>();
+        static List<string> s_CreatedAssetNames = new List<string>();
         
         public static void Create(Transform parent, GeometryTypes geometryType, Link.Geometry geometry = null)
         {
@@ -212,12 +214,13 @@ namespace Unity.Robotics.UrdfImporter
                             meshIndex++;
                             string name = $"{filePath}/{templateFileName}_{meshIndex}.asset";
                             // Only create new asset if one doesn't exist or should overwrite
-                            if ((UrdfRobotExtensions.importsettings.OverwriteExistingPrefabs || !RuntimeUrdf.AssetExists(name)) && !CreatedAssetNames.Contains(name))
+                            if ((UrdfRobotExtensions.importsettings.OverwriteExistingPrefabs || !RuntimeUrdf.AssetExists(name)) && !s_CreatedAssetNames.Contains(name))
                             {
                                 Debug.Log($"Creating new mesh file: {name}");
                                 RuntimeUrdf.AssetDatabase_CreateAsset(c, name);
                                 RuntimeUrdf.AssetDatabase_SaveAssets();
-                                CreatedAssetNames.Add(name);
+                                s_CreatedAssetNames.Add(name);
+                                s_UsedTemplateFiles.Add(templateFileName);
                             }
                             else
                             {
@@ -233,6 +236,12 @@ namespace Unity.Robotics.UrdfImporter
                     Object.DestroyImmediate(meshFilter);
                 }
             }
+        }
+
+        public static void BeginNewUrdfImport()
+        {
+            s_CreatedAssetNames.Clear();
+            s_UsedTemplateFiles.Clear();
         }
 
     }

--- a/com.unity.robotics.urdf-importer/Runtime/Extensions/UrdfGeometryCollision.cs
+++ b/com.unity.robotics.urdf-importer/Runtime/Extensions/UrdfGeometryCollision.cs
@@ -21,6 +21,8 @@ namespace Unity.Robotics.UrdfImporter
 {
     public class UrdfGeometryCollision : UrdfGeometry
     {
+        public static List<string> CreatedAssetNames = new List<string>();
+        
         public static void Create(Transform parent, GeometryTypes geometryType, Link.Geometry geometry = null)
         {
             GameObject geometryGameObject = null;
@@ -209,12 +211,13 @@ namespace Unity.Robotics.UrdfImporter
                         {
                             meshIndex++;
                             string name = $"{filePath}/{templateFileName}_{meshIndex}.asset";
-                            // Only create new asset if one doesn't exist
-                            if (!RuntimeUrdf.AssetExists(name))
+                            // Only create new asset if one doesn't exist or should overwrite
+                            if ((UrdfRobotExtensions.importsettings.OverwriteExistingPrefabs || !RuntimeUrdf.AssetExists(name)) && !CreatedAssetNames.Contains(name))
                             {
                                 Debug.Log($"Creating new mesh file: {name}");
                                 RuntimeUrdf.AssetDatabase_CreateAsset(c, name);
-                                RuntimeUrdf.AssetDatabase_SaveAssets();       
+                                RuntimeUrdf.AssetDatabase_SaveAssets();
+                                CreatedAssetNames.Add(name);
                             }
                             else
                             {

--- a/com.unity.robotics.urdf-importer/Runtime/Extensions/UrdfGeometryCollision.cs
+++ b/com.unity.robotics.urdf-importer/Runtime/Extensions/UrdfGeometryCollision.cs
@@ -123,9 +123,17 @@ namespace Unity.Robotics.UrdfImporter
                 var packageRoot = UrdfAssetPathHandler.GetPackageRoot();
                 var filePath = RuntimeUrdf.AssetDatabase_GUIDToAssetPath(RuntimeUrdf.AssetDatabase_CreateFolder($"{packageRoot}", "meshes"));
                 var name =$"{filePath}/Cylinder.asset";
-                Debug.Log($"Creating new cylinder file: {name}");
-                RuntimeUrdf.AssetDatabase_CreateAsset(collider, name, uniquePath:true);
-                RuntimeUrdf.AssetDatabase_SaveAssets();    
+                // Only create new asset if one doesn't exist
+                if (!RuntimeUrdf.AssetExists(name))
+                {
+                    Debug.Log($"Creating new cylinder file: {name}");
+                    RuntimeUrdf.AssetDatabase_CreateAsset(collider, name, uniquePath:true);
+                    RuntimeUrdf.AssetDatabase_SaveAssets();       
+                }
+                else
+                {
+                    collider = RuntimeUrdf.AssetDatabase_LoadAssetAtPath<Mesh>(name);
+                }
             }
             MeshCollider current = go.AddComponent<MeshCollider>();
             current.sharedMesh = collider;
@@ -196,16 +204,25 @@ namespace Unity.Robotics.UrdfImporter
                     List<Mesh> colliderMeshes = decomposer.GenerateConvexMeshes(meshFilter.sharedMesh);
                     foreach (Mesh collider in colliderMeshes)
                     {
+                        var c = collider;
                         if (!RuntimeUrdf.IsRuntimeMode())
                         {
                             meshIndex++;
                             string name = $"{filePath}/{templateFileName}_{meshIndex}.asset";
-                            Debug.Log($"Creating new mesh file: {name}");
-                            RuntimeUrdf.AssetDatabase_CreateAsset(collider, name);
-                            RuntimeUrdf.AssetDatabase_SaveAssets();
+                            // Only create new asset if one doesn't exist
+                            if (!RuntimeUrdf.AssetExists(name))
+                            {
+                                Debug.Log($"Creating new mesh file: {name}");
+                                RuntimeUrdf.AssetDatabase_CreateAsset(c, name);
+                                RuntimeUrdf.AssetDatabase_SaveAssets();       
+                            }
+                            else
+                            {
+                                c = RuntimeUrdf.AssetDatabase_LoadAssetAtPath<Mesh>(name);
+                            }
                         }
                         MeshCollider current = child.AddComponent<MeshCollider>();
-                        current.sharedMesh = collider;
+                        current.sharedMesh = c;
                         current.convex = setConvex;
                     }
                     Component.DestroyImmediate(child.GetComponent<VHACD>());

--- a/com.unity.robotics.urdf-importer/Runtime/Extensions/UrdfLinkExtensions.cs
+++ b/com.unity.robotics.urdf-importer/Runtime/Extensions/UrdfLinkExtensions.cs
@@ -23,8 +23,8 @@ namespace Unity.Robotics.UrdfImporter
             GameObject linkObject = new GameObject("link");
             linkObject.transform.SetParentAndAlign(parent);
             UrdfLink urdfLink = linkObject.AddComponent<UrdfLink>();
-            UrdfVisualsExtensions.Create(linkObject.transform, link?.visuals);
             UrdfCollisionsExtensions.Create(linkObject.transform, link?.collisions);
+            UrdfVisualsExtensions.Create(linkObject.transform, link?.visuals);
 
             if (link != null)
             {

--- a/com.unity.robotics.urdf-importer/Runtime/Extensions/UrdfRobotExtensions.cs
+++ b/com.unity.robotics.urdf-importer/Runtime/Extensions/UrdfRobotExtensions.cs
@@ -174,6 +174,7 @@ namespace Unity.Robotics.UrdfImporter
         /// <returns></returns>
         public static IEnumerator<GameObject> Create(string filename, ImportSettings settings, bool loadStatus = false, bool forceRuntimeMode = false)
         {
+            UrdfGeometryCollision.BeginNewUrdfImport();
             ImportPipelineData im = ImportPipelineInit(filename, settings, loadStatus, forceRuntimeMode);
             if (im == null)
             {


### PR DESCRIPTION
## Proposed change(s)

URDF Import only creates an asset for a mesh if the asset doesn't already exist (e.g. multiple references to the same mesh), otherwise the asset is loaded.

### Useful links (GitHub issues, JIRA tickets, forum threads, etc.)

- [AIRO-1117](https://jira.unity3d.com/browse/AIRO-1117), [1048](https://jira.unity3d.com/browse/AIRO-1048)
- #135 
- https://github.com/Unity-Technologies/Unity-Robotics-Hub/issues/285

### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update
- [ ] Other (please describe)

## Testing and Verification

Verified that meshes remain between import, play mode, and returning to edit mode, as well as prefabbing and instantiating prefab.

### Test Configuration:
- Unity Version: 2020.3.11f
- Unity machine OS + version: MacOS 10.15.7

## Checklist
- [x] Ensured this PR is up-to-date with the `dev` branch
- [x] Created this PR to target the `dev` branch
- [x] Followed the style guidelines as described in the [Contribution Guidelines](https://github.com/Unity-Technologies/URDF-Importer/blob/main/CONTRIBUTING.md)
- [ ] Added tests that prove my fix is effective or that my feature works
- [x] Increased the [test coverage criteria](https://github.com/Unity-Technologies/URDF-Importer/blob/dev/.yamato/yamato-config.yml#L18) by 3%
- [x] Updated the [Changelog](https://github.com/Unity-Technologies/URDF-Importer/blob/dev/com.unity.robotics.urdf-importer/CHANGELOG.md) and described changes in the [Unreleased section](https://github.com/Unity-Technologies/URDF-Importer/blob/dev/com.unity.robotics.urdf-importer/CHANGELOG.md#unreleased)
- [x] Updated the documentation as appropriate