### PR TITLE
[Bug-Fix] Fixing inability to read relative file paths

### DIFF
--- a/com.unity.robotics.urdf-importer/Runtime/AssetHandlers/UrdfAssetPathHandler.cs
+++ b/com.unity.robotics.urdf-importer/Runtime/AssetHandlers/UrdfAssetPathHandler.cs
@@ -98,10 +98,6 @@ namespace Unity.Robotics.UrdfImporter
                    UnityEngine.Debug.LogWarning("Attempting to replace file path's starting instance of `../` with standard package notation `package://` to prevent manual path traversal at root of directory!");
                    urdfPath = $@"package://{urdfPath.Substring(3)}";
                 }
-                else
-                {
-                   return null;
-                }
             }
             // loading assets relative path from ROS/ROS2 package.
             if (urdfPath.StartsWith(@"package://"))
@@ -116,7 +112,7 @@ namespace Unity.Robotics.UrdfImporter
             }
             else
             {
-                throw new Exception(urdfPath + " is not supported URI format.");
+                path = urdfPath.SetSeparatorChar();
             }
 
             if (convertToPrefab) 


### PR DESCRIPTION
## Proposed change(s)
Fix a regression from a previous pull request where the function UrdfAssetPathHandler.GetRelativeAssetPathFromUrdfPath was returning null in case the file path is of format "folder1/folder2/example.stl".

### Useful links (GitHub issues, JIRA tickets, forum threads, etc.)
https://github.com/Unity-Technologies/URDF-Importer/pull/147/files#r718991313
https://jira.unity3d.com/browse/AIRO-1349

### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update
- [ ] Other (please describe)

## Testing and Verification

Please describe the tests that you ran to verify your changes. Please also provide instructions, ROS packages, and Unity project files as appropriate so we can reproduce the test environment. 

### Test Configuration:
- Unity Version: [e.g. Unity 2020.2.0f1]
- Unity machine OS + version: [e.g. Windows 10]
- ROS machine OS + version: [e.g. Ubuntu 18.04, ROS Noetic]
- ROS–Unity communication: [e.g. Docker]

## Checklist
- [x] Ensured this PR is up-to-date with the `dev` branch
- [x] Created this PR to target the `dev` branch
- [ ] Followed the style guidelines as described in the [Contribution Guidelines](https://github.com/Unity-Technologies/URDF-Importer/blob/main/CONTRIBUTING.md)
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Increased the [test coverage criteria](https://github.com/Unity-Technologies/URDF-Importer/blob/dev/.yamato/yamato-config.yml#L18) by 3%
- [ ] Updated the [Changelog](https://github.com/Unity-Technologies/URDF-Importer/blob/dev/com.unity.robotics.urdf-importer/CHANGELOG.md) and described changes in the [Unreleased section](https://github.com/Unity-Technologies/URDF-Importer/blob/dev/com.unity.robotics.urdf-importer/CHANGELOG.md#unreleased)
- [ ] Updated the documentation as appropriate

## Other comments