### PR TITLE
AIRO-1504 Fix IsRevoluteOrContinuous in UrdfJoint.cs

### DIFF
--- a/TestUrdfImporter/Assets/resources.meta
+++ b/TestUrdfImporter/Assets/resources.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 211f95d7dee974bc4866ade4e1bee52a
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.robotics.urdf-importer/Runtime/UrdfComponents/UrdfJoints/UrdfJoint.cs
+++ b/com.unity.robotics.urdf-importer/Runtime/UrdfComponents/UrdfJoints/UrdfJoint.cs
@@ -45,7 +45,7 @@ namespace Unity.Robotics.UrdfImporter
         public string jointName;
 
         public abstract JointTypes JointType { get; } // Clear out syntax
-        public bool IsRevoluteOrContinuous => JointType == JointTypes.Revolute || JointType == JointTypes.Revolute;
+        public bool IsRevoluteOrContinuous => JointType == JointTypes.Revolute || JointType == JointTypes.Continuous;
         public double EffortLimit = 1e3;
         public double VelocityLimit = 1e3;
 

--- a/com.unity.robotics.urdf-importer/Tests/Runtime/UrdfComponents/UrdfJoints/UrdfJointTests.cs
+++ b/com.unity.robotics.urdf-importer/Tests/Runtime/UrdfComponents/UrdfJoints/UrdfJointTests.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using NUnit.Framework;
 using UnityEngine;
 using Unity.Robotics.UrdfImporter;
+using UnityEditor;
 using Joint = Unity.Robotics.UrdfImporter.Joint;
 
 namespace Unity.Robotics.UrdfImporter.Tests
@@ -22,7 +23,8 @@ namespace Unity.Robotics.UrdfImporter.Tests
 
 #if UNITY_2020_1_OR_NEWER
         [Test, TestCaseSource("JointTypes")]
-        public void Create_UrdfJoint_Succeeds(UrdfJoint.JointTypes urdfJointType, ArticulationJointType articulationJointType)
+        public void Create_UrdfJoint_Succeeds(UrdfJoint.JointTypes urdfJointType,
+            ArticulationJointType articulationJointType, bool isRevoluteOrContinuousJoint)
         {
             GameObject linkObject = new GameObject("link");
             UrdfJoint urdfJoint = UrdfJoint.Create(linkObject, urdfJointType);
@@ -32,6 +34,7 @@ namespace Unity.Robotics.UrdfImporter.Tests
             Assert.IsNotNull(articulationBody);
             Assert.AreEqual(urdfJointType, urdfJoint.JointType);
             Assert.AreEqual(articulationJointType, articulationBody.jointType);
+            Assert.AreEqual(isRevoluteOrContinuousJoint, urdfJoint.IsRevoluteOrContinuous);
 
             Object.DestroyImmediate(linkObject);
         }
@@ -40,12 +43,12 @@ namespace Unity.Robotics.UrdfImporter.Tests
         {
             get
             {
-                yield return new TestCaseData(UrdfJoint.JointTypes.Fixed, ArticulationJointType.FixedJoint);
-                yield return new TestCaseData(UrdfJoint.JointTypes.Continuous, ArticulationJointType.RevoluteJoint);
-                yield return new TestCaseData(UrdfJoint.JointTypes.Floating, ArticulationJointType.FixedJoint);
-                yield return new TestCaseData(UrdfJoint.JointTypes.Planar, ArticulationJointType.PrismaticJoint);
-                yield return new TestCaseData(UrdfJoint.JointTypes.Prismatic, ArticulationJointType.PrismaticJoint);
-                yield return new TestCaseData(UrdfJoint.JointTypes.Revolute, ArticulationJointType.RevoluteJoint);
+                yield return new TestCaseData(UrdfJoint.JointTypes.Fixed, ArticulationJointType.FixedJoint, false);
+                yield return new TestCaseData(UrdfJoint.JointTypes.Continuous, ArticulationJointType.RevoluteJoint, true);
+                yield return new TestCaseData(UrdfJoint.JointTypes.Floating, ArticulationJointType.FixedJoint, false);
+                yield return new TestCaseData(UrdfJoint.JointTypes.Planar, ArticulationJointType.PrismaticJoint, false);
+                yield return new TestCaseData(UrdfJoint.JointTypes.Prismatic, ArticulationJointType.PrismaticJoint, false);
+                yield return new TestCaseData(UrdfJoint.JointTypes.Revolute, ArticulationJointType.RevoluteJoint, true);
             }
         }
 


### PR DESCRIPTION
## Proposed change(s)

Copied from PR https://github.com/Unity-Technologies/URDF-Importer/pull/158

This PR updated UrdfJoint.cs to correct an issue with the `IsRevoluteOrContinuous` var that previously only checked if the joint was a `Revolute`

### Useful links (GitHub issues, JIRA tickets, forum threads, etc.)

None

### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update
- [ ] Other (please describe)

## Testing and Verification

Please describe the tests that you ran to verify your changes. Please also provide instructions, ROS packages, and Unity project files as appropriate so we can reproduce the test environment. 

### Test Configuration:
- Unity Version: Unity 2021.2.1
- Unity machine OS + version: Arch Linux
- ROS machine OS + version: Ubuntu 18.04
- ROS–Unity communication: Docker

## Checklist
- [x] Ensured this PR is up-to-date with the `dev` branch
- [x] Created this PR to target the `dev` branch
- [x] Followed the style guidelines as described in the [Contribution Guidelines](https://github.com/Unity-Technologies/URDF-Importer/blob/main/CONTRIBUTING.md)
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Increased the [test coverage criteria](https://github.com/Unity-Technologies/URDF-Importer/blob/dev/.yamato/yamato-config.yml#L18) by 3%
- [ ] Updated the [Changelog](https://github.com/Unity-Technologies/URDF-Importer/blob/dev/com.unity.robotics.urdf-importer/CHANGELOG.md) and described changes in the [Unreleased section](https://github.com/Unity-Technologies/URDF-Importer/blob/dev/com.unity.robotics.urdf-importer/CHANGELOG.md#unreleased)
- [ ] Updated the documentation as appropriate

## Other comments

Seems like a simple fix, the previous version didn't really make sense? To be fair I'm not quite sure what this file is for, I'm just using it to publish joint data back to ROS in my own script (I needed the joint name, which was stored on each Articulation Body in this component).