### PR TITLE
AIRO-1703 Inertia tensor rotation set to zero if NaN values produced during inertia matrix conversion.

### DIFF
--- a/com.unity.robotics.urdf-importer/CHANGELOG.md
+++ b/com.unity.robotics.urdf-importer/CHANGELOG.md
@@ -20,7 +20,7 @@ Add capsule shape support
 ### Removed
 
 ### Fixed
-
+- Added check for NaN values during inertia matrix's conversion to inertia tensor rotation.
 
 ## [0.5.2-preview] - 2022-02-01
 

--- a/com.unity.robotics.urdf-importer/Runtime/UrdfComponents/UrdfInertial.cs
+++ b/com.unity.robotics.urdf-importer/Runtime/UrdfComponents/UrdfInertial.cs
@@ -149,7 +149,11 @@ namespace Unity.Robotics.UrdfImporter
             
 
             robotLink.inertiaTensor = ToUnityInertiaTensor(FixMinInertia(eigenvalues));
-            robotLink.inertiaTensorRotation = ToQuaternion(eigenvectors[0], eigenvectors[1], eigenvectors[2]).Ros2Unity() * this.inertialAxisRotation;
+            var tensorRotation = ToQuaternion(eigenvectors[0], eigenvectors[1], eigenvectors[2]).Ros2Unity() * this.inertialAxisRotation;
+            if (float.IsNaN(tensorRotation.x) || float.IsNaN(tensorRotation.y) || float.IsNaN(tensorRotation.z))
+                robotLink.inertiaTensorRotation = Quaternion.identity;
+            else
+                robotLink.inertiaTensorRotation = tensorRotation;
 
             this.centerOfMass = robotLink.centerOfMass;
             this.inertiaTensor = robotLink.inertiaTensor;


### PR DESCRIPTION
## Proposed change(s)

Change has been made to UrdfInertial.cs. The importer will set the inertia tensor rotation to zero if the inertia tensor rotation produced from the inertial matrix has NaN values.

### Useful links (GitHub issues, JIRA tickets, forum threads, etc.)

https://github.com/Unity-Technologies/Unity-Robotics-Hub/issues/343

### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update
- [ ] Other (please describe)

## Testing and Verification

Please describe the tests that you ran to verify your changes. Please also provide instructions, ROS packages, and Unity project files as appropriate so we can reproduce the test environment. 

### Test Configuration:
- Unity Version: [e.g. Unity 2020.2.0f1]
- Unity machine OS + version: [e.g. Windows 10]
- ROS machine OS + version: [e.g. Ubuntu 18.04, ROS Noetic]
- ROS–Unity communication: [e.g. Docker]

## Checklist
- [x] Ensured this PR is up-to-date with the `dev` branch
- [x] Created this PR to target the `dev` branch
- [x] Followed the style guidelines as described in the [Contribution Guidelines](https://github.com/Unity-Technologies/URDF-Importer/blob/main/CONTRIBUTING.md)
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Increased the [test coverage criteria](https://github.com/Unity-Technologies/URDF-Importer/blob/dev/.yamato/yamato-config.yml#L18) by 3%
- [x] Updated the [Changelog](https://github.com/Unity-Technologies/URDF-Importer/blob/dev/com.unity.robotics.urdf-importer/CHANGELOG.md) and described changes in the [Unreleased section](https://github.com/Unity-Technologies/URDF-Importer/blob/dev/com.unity.robotics.urdf-importer/CHANGELOG.md#unreleased)
- [ ] Updated the documentation as appropriate

## Other comments