### PR TITLE
AIRO-1690 Removing option to convert all meshColliders to non convex type meshes

### DIFF
--- a/com.unity.robotics.urdf-importer/CHANGELOG.md
+++ b/com.unity.robotics.urdf-importer/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 ## Unreleased
 
 ### Upgrade Notes
+- Added check for NaN values during inertia matrix's conversion to inertia tensor rotation.
 
 ### Known Issues
 

--- a/com.unity.robotics.urdf-importer/CHANGELOG.md
+++ b/com.unity.robotics.urdf-importer/CHANGELOG.md
@@ -7,7 +7,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 ## Unreleased
 
 ### Upgrade Notes
-- Added check for NaN values during inertia matrix's conversion to inertia tensor rotation.
 
 ### Known Issues
 
@@ -19,6 +18,7 @@ Add capsule shape support
 ### Deprecated
 
 ### Removed
+- Removed option on UrdfRobot inspector window to set all MeshColliders to non-Convex meshes.
 
 ### Fixed
 

--- a/com.unity.robotics.urdf-importer/Editor/CustomEditors/UrdfRobotEditor.cs
+++ b/com.unity.robotics.urdf-importer/Editor/CustomEditors/UrdfRobotEditor.cs
@@ -45,10 +45,6 @@ namespace Unity.Robotics.UrdfImporter.Editor
             DisplaySettingsToggle(new GUIContent("Default Space"), urdfRobot.ChangeToCorrectedSpace,UrdfRobot.changetoCorrectedSpace);
 
             GUILayout.Space(5);
-            GUILayout.Label("All Colliders", EditorStyles.boldLabel);
-            DisplaySettingsToggle(new GUIContent("Convex"), urdfRobot.SetCollidersConvex,UrdfRobot.collidersConvex);
-
-            GUILayout.Space(5);
             GUILayout.Label("All Joints", EditorStyles.boldLabel);
             EditorGUILayout.BeginHorizontal();
             EditorGUILayout.PrefixLabel("Generate Unique Joint Names");

--- a/com.unity.robotics.urdf-importer/Runtime/UrdfComponents/UrdfRobot.cs
+++ b/com.unity.robotics.urdf-importer/Runtime/UrdfComponents/UrdfRobot.cs
@@ -37,15 +37,7 @@ namespace Unity.Robotics.UrdfImporter
         public static bool changetoCorrectedSpace = false;
 
         #region Configure Robot
-
-        public void SetCollidersConvex()
-        {
-            foreach (MeshCollider meshCollider in GetComponentsInChildren<MeshCollider>())
-                meshCollider.convex = !collidersConvex;
-            collidersConvex = !collidersConvex;
-        }
-
-
+        
         public void SetUseUrdfInertiaData()
         {
             foreach (UrdfInertial urdfInertial in GetComponentsInChildren<UrdfInertial>())


### PR DESCRIPTION
## Proposed change(s)

Removing a button in the inspector window of the UrdfRobot script that allows the user to toggle "is convex" option for colliders. Non-convex meshes are incompatible with ArticulationBodies, which is the only supported Physics entity in Unity, hence making the functionality unuseful.
### Useful links (GitHub issues, JIRA tickets, forum threads, etc.)

https://github.com/Unity-Technologies/URDF-Importer/issues/171
### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [x] Code refactor
- [ ] Documentation update
- [ ] Other (please describe)

## Testing and Verification

Please describe the tests that you ran to verify your changes. Please also provide instructions, ROS packages, and Unity project files as appropriate so we can reproduce the test environment. 

### Test Configuration:
- Unity Version: [e.g. Unity 2020.2.0f1]
- Unity machine OS + version: [e.g. Windows 10]
- ROS machine OS + version: [e.g. Ubuntu 18.04, ROS Noetic]
- ROS–Unity communication: [e.g. Docker]

## Checklist
- [x] Ensured this PR is up-to-date with the `dev` branch
- [x] Created this PR to target the `dev` branch
- [ ] Followed the style guidelines as described in the [Contribution Guidelines](https://github.com/Unity-Technologies/URDF-Importer/blob/main/CONTRIBUTING.md)
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Increased the [test coverage criteria](https://github.com/Unity-Technologies/URDF-Importer/blob/dev/.yamato/yamato-config.yml#L18) by 3%
- [x] Updated the [Changelog](https://github.com/Unity-Technologies/URDF-Importer/blob/dev/com.unity.robotics.urdf-importer/CHANGELOG.md) and described changes in the [Unreleased section](https://github.com/Unity-Technologies/URDF-Importer/blob/dev/com.unity.robotics.urdf-importer/CHANGELOG.md#unreleased)
- [ ] Updated the documentation as appropriate

## Other comments