### PR TITLE
AIRO-1782 Fix behavior of 'Use URDF Values' check-box (and re-name)

### DIFF
--- a/com.unity.robotics.urdf-importer/CHANGELOG.md
+++ b/com.unity.robotics.urdf-importer/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 - Added mesh filetype export support for .dae, .obj, .fbx, .ma, .max, .jas, .dxf, .c4d, .blend, .lxo, .3ds
 
 ### Changed
+- Changed "Use URDF Values" to "Override URDF Values" in URDF Inertial scripts and updated behavior to match expectation
 
 ### Deprecated
 

--- a/com.unity.robotics.urdf-importer/Editor/CustomEditors/UrdfInertialEditor.cs
+++ b/com.unity.robotics.urdf-importer/Editor/CustomEditors/UrdfInertialEditor.cs
@@ -14,6 +14,7 @@ limitations under the License.
 
 using UnityEditor;
 using UnityEngine;
+using UnityEngine.Assertions;
 
 namespace Unity.Robotics.UrdfImporter.Editor
 {
@@ -22,27 +23,64 @@ namespace Unity.Robotics.UrdfImporter.Editor
     {
         private Vector3 testVector;
 
+        bool ResetInertialsButton()
+        {
+            return GUILayout.Button("Reset Overrides");
+        }
+
         public override void OnInspectorGUI()
         {
             UrdfInertial urdfInertial = (UrdfInertial) target;
-
+            
             GUILayout.Space(5);
-            urdfInertial.displayInertiaGizmo =
-                EditorGUILayout.ToggleLeft("Display Inertia Gizmo", urdfInertial.displayInertiaGizmo);
-            GUILayout.Space(5);
-
-            bool newValue = EditorGUILayout.BeginToggleGroup("Use URDF Data", urdfInertial.useUrdfData);
-            EditorGUILayout.Vector3Field("URDF Center of Mass", urdfInertial.centerOfMass);
-            EditorGUILayout.Vector3Field("URDF Inertia Tensor", urdfInertial.inertiaTensor);
-            EditorGUILayout.Vector3Field("URDF Inertia Tensor Rotation",
-                urdfInertial.inertiaTensorRotation.eulerAngles);
+            var shouldOverride = 
+                EditorGUILayout.BeginToggleGroup("Override URDF Data", !urdfInertial.useUrdfData);
+            EditorGUI.BeginChangeCheck();
+            var centerOfMass = 
+                EditorGUILayout.Vector3Field("URDF Center of Mass", urdfInertial.centerOfMass);
+            var inertiaTensor = 
+                EditorGUILayout.Vector3Field("URDF Inertia Tensor", urdfInertial.inertiaTensor);
+            var inertialChanged = EditorGUI.EndChangeCheck();
+            EditorGUI.BeginChangeCheck();
+            var eulerAngles = 
+                EditorGUILayout.Vector3Field("URDF Inertia Tensor Rotation",
+                    urdfInertial.inertiaTensorRotation.eulerAngles);
+            var anglesChanged = EditorGUI.EndChangeCheck();
+            
+            var shouldReset = ResetInertialsButton();
             EditorGUILayout.EndToggleGroup();
 
-            if (newValue != urdfInertial.useUrdfData)
+            var toggleOccured = urdfInertial.useUrdfData == shouldOverride;
+            
+            // Leaving a bunch of asserts in here because I'm pretty sure multiple change checks can't be true at the
+            // same time, but not positive...
+            if (toggleOccured) 
             {
-                urdfInertial.useUrdfData = newValue;
-                urdfInertial.UpdateLinkData();
+                Assert.IsFalse(inertialChanged || anglesChanged || shouldReset);
+                Undo.RecordObject(urdfInertial, "Toggle URDF Overrides");
+                urdfInertial.useUrdfData = !shouldOverride;
             }
+            else if (inertialChanged)
+            {
+                Assert.IsFalse(anglesChanged || shouldReset);
+                Undo.RecordObject(urdfInertial, "Change URDF Inertial Values");
+                urdfInertial.centerOfMass = centerOfMass;
+                urdfInertial.inertiaTensor = inertiaTensor;
+            }
+            else if (anglesChanged)
+            {
+                Assert.IsFalse(shouldReset);
+                Undo.RecordObject(urdfInertial, "Change URDF Inertial tensor rotation");
+                urdfInertial.inertiaTensorRotation.eulerAngles = eulerAngles;
+            }
+            else if (shouldReset)
+            {
+                Undo.RecordObject(urdfInertial, "Reset URDF Inertial Values");
+                urdfInertial.ResetInertial();
+                return;
+            }
+            
+            urdfInertial.UpdateLinkData(toggleOccured);
         }
     }
 }

--- a/com.unity.robotics.urdf-importer/Runtime/RosSharpDefinitions/Link.cs
+++ b/com.unity.robotics.urdf-importer/Runtime/RosSharpDefinitions/Link.cs
@@ -76,6 +76,7 @@ namespace Unity.Robotics.UrdfImporter
             return visuals.ToList();
         }
 
+        [System.Serializable]
         public class Inertial
         {
             public double mass;
@@ -111,6 +112,7 @@ namespace Unity.Robotics.UrdfImporter
                 writer.WriteEndElement();
             }
 
+            [System.Serializable]
             public class Inertia
             {
                 public double ixx;

--- a/com.unity.robotics.urdf-importer/Runtime/RosSharpDefinitions/Link.cs
+++ b/com.unity.robotics.urdf-importer/Runtime/RosSharpDefinitions/Link.cs
@@ -97,6 +97,13 @@ namespace Unity.Robotics.UrdfImporter
                 this.inertia = inertia;
             }
 
+            public Inertial(Inertial other)
+            {
+                mass = other.mass;
+                origin = other.origin;
+                inertia = other.inertia;
+            }
+
             public void WriteToUrdf(XmlWriter writer)
             {
                 writer.WriteStartElement("inertial");

--- a/com.unity.robotics.urdf-importer/Runtime/UrdfComponents/UrdfInertial.cs
+++ b/com.unity.robotics.urdf-importer/Runtime/UrdfComponents/UrdfInertial.cs
@@ -14,71 +14,94 @@ limitations under the License.
 
 using System;
 using UnityEngine;
+using UnityEngine.Assertions;
 
 namespace Unity.Robotics.UrdfImporter
 {
     [RequireComponent(typeof(ArticulationBody))]
     public class UrdfInertial : MonoBehaviour
     {
-        public bool displayInertiaGizmo;
-
+        const int k_RoundDigits = 10;
+        const float k_MinInertia = 1e-6f;
+        const float k_MinMass = 0.1f;
+        
         public bool useUrdfData;
         public Vector3 centerOfMass;
         public Vector3 inertiaTensor;
         public Quaternion inertiaTensorRotation;
         public Quaternion inertialAxisRotation;
 
-        private const int RoundDigits = 10;
-        private const float MinInertia = 1e-6f;
-        private const float minMass = 0.1f;
+        [SerializeField, HideInInspector]
+        Link.Inertial m_OriginalValues;
+        
+        [SerializeField, HideInInspector]
+        Link.Inertial m_Overrides;
 
-        public static void Create(GameObject linkObject, Link.Inertial inertial = null)
+        public static void Create(GameObject linkObject, Link.Inertial inertialLink = null)
         {
-            UrdfInertial urdfInertial = linkObject.AddComponent<UrdfInertial>();
-
-            ArticulationBody robotLink = urdfInertial.GetComponent<ArticulationBody>();
-
-            if (inertial != null)
+            var inertialUrdf = linkObject.AddComponent<UrdfInertial>();
+            if (inertialLink != null)
             {
-                robotLink.mass = ((float)inertial.mass > 0)?((float)inertial.mass):minMass;
-                if (inertial.origin != null) {
-                    
-                    robotLink.centerOfMass = UrdfOrigin.GetPositionFromUrdf(inertial.origin);
-                }
-                else
-                {
-                    robotLink.centerOfMass = Vector3.zero;
-                }
-                urdfInertial.ImportInertiaData(inertial);
-                 
-                urdfInertial.useUrdfData = true;
+                inertialUrdf.m_OriginalValues = inertialLink;
+                inertialUrdf.useUrdfData = true;
+                inertialUrdf.UpdateLinkData();
             }
+            else if (inertialUrdf.TryGetComponent<ArticulationBody>(out var robotLink))
+            {
+                inertialUrdf.m_Overrides = inertialUrdf.ToLinkInertial(robotLink);
+                // NOTE: The first time this is set to true, we'll save the current state of m_Overrides as the default,
+                //       since there is no actual URDF data to default to
+                inertialUrdf.useUrdfData = false;
+            }
+        }
 
-            urdfInertial.displayInertiaGizmo = false;
+        public void ResetInertial()
+        {
+            m_Overrides = m_OriginalValues;
+            AssignUrdfInertiaData(m_Overrides);
         }
 
 #region Runtime
 
-        private void Start()
+        void OnEnable()
         {
             UpdateLinkData();
         }
 
-        public void UpdateLinkData()
+        public void UpdateLinkData(bool copyOverrides = false)
         {
-
-            ArticulationBody robotLink = GetComponent<ArticulationBody>();
-
+            var robotLink = GetComponent<ArticulationBody>();
+            if (robotLink == null)
+            {
+                return;
+            }
+            
             if (useUrdfData)
+            {
+                if (m_OriginalValues == null)
+                {
+                    Debug.LogWarning(
+                        "This instance doesn't have any urdf data stored - " +
+                        "creating some using the current inertial values.");
+                    m_OriginalValues = ToLinkInertial(robotLink);
+                }
+                Assert.IsNotNull(m_OriginalValues);
+                if (copyOverrides)
+                {
+                    m_Overrides = ToLinkInertial(robotLink);
+                }
+                AssignUrdfInertiaData(m_OriginalValues);
+            }
+            else if (copyOverrides)
+            {
+                m_Overrides ??= m_OriginalValues;
+                AssignUrdfInertiaData(m_Overrides);
+            }
+            else
             {
                 robotLink.centerOfMass = centerOfMass;
                 robotLink.inertiaTensor = inertiaTensor;
                 robotLink.inertiaTensorRotation = inertiaTensorRotation * inertialAxisRotation;
-            }
-            else
-            {
-                robotLink.ResetCenterOfMass();
-                robotLink.ResetInertiaTensor();
             }
         }
 
@@ -86,19 +109,28 @@ namespace Unity.Robotics.UrdfImporter
 
 #region Import
 
-        private void ImportInertiaData(Link.Inertial inertial)
+        void AssignUrdfInertiaData(Link.Inertial linkInertial)
         {
+            Assert.IsNotNull(linkInertial);
+            var robotLink = GetComponent<ArticulationBody>();
+            robotLink.mass = (float)linkInertial.mass > 0 
+                ? (float)linkInertial.mass 
+                : k_MinMass;
+            
+            robotLink.centerOfMass = linkInertial.origin != null 
+                ? UrdfOrigin.GetPositionFromUrdf(linkInertial.origin) 
+                : Vector3.zero;
+            
             Vector3 eigenvalues;
             Vector3[] eigenvectors;
-            Matrix3x3 rotationMatrix = ToMatrix3x3(inertial.inertia);
+            Matrix3x3 rotationMatrix = ToMatrix3x3(linkInertial.inertia);
             rotationMatrix.DiagonalizeRealSymmetric(out eigenvalues, out eigenvectors);
-            ArticulationBody robotLink = GetComponent<ArticulationBody>();
 
             Vector3 inertiaEulerAngles;
 
-            if (inertial.origin != null)
+            if (linkInertial.origin != null)
             {
-                inertiaEulerAngles = UrdfOrigin.GetRotationFromUrdf(inertial.origin);
+                inertiaEulerAngles = UrdfOrigin.GetRotationFromUrdf(linkInertial.origin);
             }
             else
             {
@@ -138,8 +170,8 @@ namespace Unity.Robotics.UrdfImporter
         {
             for (int i = 0; i < 3; i++)
             {
-                if (vector3[i] < MinInertia)
-                    vector3[i] = MinInertia;
+                if (vector3[i] < k_MinInertia)
+                    vector3[i] = k_MinInertia;
             }
             return vector3;
         }
@@ -187,24 +219,34 @@ namespace Unity.Robotics.UrdfImporter
 #endregion
 
 #region Export
-        public Link.Inertial ExportInertialData() 
+        public Link.Inertial ExportInertialData()
         {
-            ArticulationBody robotLink = GetComponent<ArticulationBody>();
+            var robotLink = GetComponent<ArticulationBody>();
 
             if (robotLink == null)
+            {
+                Debug.LogWarning("No data to export.");
                 return null;
+            }
 
             UpdateLinkData();
-            Vector3 originAngles = inertialAxisRotation.eulerAngles;
-            Origin inertialOrigin = new Origin(robotLink.centerOfMass.Unity2Ros().ToRoundedDoubleArray(), new double[] { (double)originAngles.x, (double)originAngles.y, (double)originAngles.z });
-            Link.Inertial.Inertia inertia = ExportInertiaData();
+            return ToLinkInertial(robotLink);
+        }
 
-            return new Link.Inertial(Math.Round(robotLink.mass, RoundDigits), inertialOrigin, inertia);
+        Link.Inertial ToLinkInertial(ArticulationBody robotLink)
+        {
+            var originAngles = inertialAxisRotation.eulerAngles;
+            var inertialOrigin = new Origin(
+                robotLink.centerOfMass.Unity2Ros().ToRoundedDoubleArray(), 
+                new double[] { (double)originAngles.x, (double)originAngles.y, (double)originAngles.z });
+            var inertia = ExportInertiaData();
+
+            return new Link.Inertial(Math.Round(robotLink.mass, k_RoundDigits), inertialOrigin, inertia);
         }
 
         private Link.Inertial.Inertia ExportInertiaData()
         {
-            ArticulationBody robotLink = GetComponent<ArticulationBody>();
+            var robotLink = GetComponent<ArticulationBody>();
             
             Matrix3x3 lamdaMatrix = new Matrix3x3(new[] {
                 robotLink.inertiaTensor[0],

--- a/com.unity.robotics.urdf-importer/Runtime/UrdfComponents/UrdfInertial.cs
+++ b/com.unity.robotics.urdf-importer/Runtime/UrdfComponents/UrdfInertial.cs
@@ -73,8 +73,8 @@ namespace Unity.Robotics.UrdfImporter
 
         public void UpdateLinkData(bool copyOverrides = false)
         {
-            var robotLink = GetComponent<ArticulationBody>();
-            if (robotLink == null)
+            var articulationBody = GetComponent<ArticulationBody>();
+            if (articulationBody == null)
             {
                 return;
             }
@@ -86,26 +86,28 @@ namespace Unity.Robotics.UrdfImporter
                     Debug.LogWarning(
                         "This instance doesn't have any urdf data stored - " +
                         "creating some using the current inertial values.");
-                    m_OriginalValues = ToLinkInertial(robotLink);
+                    m_OriginalValues = ToLinkInertial(articulationBody);
                 }
                 Assert.IsNotNull(m_OriginalValues);
                 if (copyOverrides)
                 {
-                    m_Overrides = ToLinkInertial(robotLink);
+                    m_Overrides = ToLinkInertial(articulationBody);
                 }
                 AssignUrdfInertiaData(m_OriginalValues);
+                return;
             }
-            else if (copyOverrides)
+            
+            if (copyOverrides)
             {
-                m_Overrides ??= m_OriginalValues;
-                AssignUrdfInertiaData(m_Overrides);
+                m_Overrides ??= new Link.Inertial(m_OriginalValues);
             }
-            else
+            // Ensure that when this script is hot-loaded for the first time that this previously non-existent variable
+            // gets some sensible values (by copying them from the current state of the ArticulationBody)
+            else if (m_Overrides == null)
             {
-                robotLink.centerOfMass = centerOfMass;
-                robotLink.inertiaTensor = FixMinInertia(inertiaTensor);
-                robotLink.inertiaTensorRotation = inertiaTensorRotation * inertialAxisRotation;
+                m_Overrides = ToLinkInertial(articulationBody);
             }
+            AssignUrdfInertiaData(m_Overrides);
         }
 
 #endregion

--- a/com.unity.robotics.urdf-importer/Runtime/UrdfComponents/UrdfInertial.cs
+++ b/com.unity.robotics.urdf-importer/Runtime/UrdfComponents/UrdfInertial.cs
@@ -47,7 +47,6 @@ namespace Unity.Robotics.UrdfImporter
             }
             else if (inertialUrdf.TryGetComponent<ArticulationBody>(out var robotLink))
             {
-                //robotLink.inertiaTensor = FixMinInertia(robotLink.inertiaTensor);
                 robotLink.mass = Mathf.Max(robotLink.mass, k_MinMass);
 
                 inertialUrdf.m_Overrides = inertialUrdf.ToLinkInertial(robotLink);


### PR DESCRIPTION
## Proposed change(s)

CDP user Robyn described [an issue](https://unity.slack.com/archives/C032A4LGLKZ/p1646260555062479) where the "Use URDF Values" check-box didn't behave the way they expected (values are greyed out when box is not checked, and are only "editable" when being "used," although the values were being reset immediately when changed). 

Re-named the checkbox to "Override URDF Values" to be more in-line with the toggle-group behavior, and corrected behavior so that when the values are editable, the edits made are appropriately propagated to the underlying ArticulationBody. Also added a button that resets the override values back to those originally defined in the URDF, and added logic so that when the Overrides box is unchecked, it appropriately toggles back to the original URDF values.  Also also added a type alias at the top of the file and cleaned up superfluous `if #UNITY_EDITOR` pre-processor directives.

Tested manually in editor.


### Useful links (GitHub issues, JIRA tickets, forum threads, etc.)

Provide any relevant links here.

### Types of change(s)

- [x] Bug fix
- [x] Code refactor

## Checklist
- [x] Ensured this PR is up-to-date with the `dev` branch
- [x] Created this PR to target the `dev` branch
- [x] Followed the style guidelines as described in the [Contribution Guidelines](https://github.com/Unity-Technologies/URDF-Importer/blob/main/CONTRIBUTING.md)
- [x] Updated the [Changelog](https://github.com/Unity-Technologies/URDF-Importer/blob/dev/com.unity.robotics.urdf-importer/CHANGELOG.md) and described changes in the [Unreleased section](https://github.com/Unity-Technologies/URDF-Importer/blob/dev/com.unity.robotics.urdf-importer/CHANGELOG.md#unreleased)

https://user-images.githubusercontent.com/29758400/162850424-e9de5550-4e63-4cf7-a0f4-ad56128c4bb9.mp4


