### PR TITLE
AIRO-1946 URDFInertial behavior bugfix

### DIFF
--- a/com.unity.robotics.urdf-importer/CHANGELOG.md
+++ b/com.unity.robotics.urdf-importer/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 - Added mesh filetype export support for .dae, .obj, .fbx, .ma, .max, .jas, .dxf, .c4d, .blend, .lxo, .3ds
 
 ### Changed
+- Changed "Use URDF Values" to "Override URDF Values" in URDF Inertial scripts and updated behavior to match expectation
 
 ### Deprecated
 

--- a/com.unity.robotics.urdf-importer/Editor/CustomEditors/UrdfInertialEditor.cs
+++ b/com.unity.robotics.urdf-importer/Editor/CustomEditors/UrdfInertialEditor.cs
@@ -14,6 +14,7 @@ limitations under the License.
 
 using UnityEditor;
 using UnityEngine;
+using UnityEngine.Assertions;
 
 namespace Unity.Robotics.UrdfImporter.Editor
 {
@@ -22,27 +23,64 @@ namespace Unity.Robotics.UrdfImporter.Editor
     {
         private Vector3 testVector;
 
+        bool ResetInertialsButton()
+        {
+            return GUILayout.Button("Reset Overrides");
+        }
+
         public override void OnInspectorGUI()
         {
             UrdfInertial urdfInertial = (UrdfInertial) target;
-
+            
             GUILayout.Space(5);
-            urdfInertial.displayInertiaGizmo =
-                EditorGUILayout.ToggleLeft("Display Inertia Gizmo", urdfInertial.displayInertiaGizmo);
-            GUILayout.Space(5);
-
-            bool newValue = EditorGUILayout.BeginToggleGroup("Use URDF Data", urdfInertial.useUrdfData);
-            EditorGUILayout.Vector3Field("URDF Center of Mass", urdfInertial.centerOfMass);
-            EditorGUILayout.Vector3Field("URDF Inertia Tensor", urdfInertial.inertiaTensor);
-            EditorGUILayout.Vector3Field("URDF Inertia Tensor Rotation",
-                urdfInertial.inertiaTensorRotation.eulerAngles);
+            var shouldOverride = 
+                EditorGUILayout.BeginToggleGroup("Override URDF Data", !urdfInertial.useUrdfData);
+            EditorGUI.BeginChangeCheck();
+            var centerOfMass = 
+                EditorGUILayout.Vector3Field("URDF Center of Mass", urdfInertial.centerOfMass);
+            var inertiaTensor = 
+                EditorGUILayout.Vector3Field("URDF Inertia Tensor", urdfInertial.inertiaTensor);
+            var inertialChanged = EditorGUI.EndChangeCheck();
+            EditorGUI.BeginChangeCheck();
+            var eulerAngles = 
+                EditorGUILayout.Vector3Field("URDF Inertia Tensor Rotation",
+                    urdfInertial.inertiaTensorRotation.eulerAngles);
+            var anglesChanged = EditorGUI.EndChangeCheck();
+            
+            var shouldReset = ResetInertialsButton();
             EditorGUILayout.EndToggleGroup();
 
-            if (newValue != urdfInertial.useUrdfData)
+            var toggleOccured = urdfInertial.useUrdfData == shouldOverride;
+            
+            // Leaving a bunch of asserts in here because I'm pretty sure multiple change checks can't be true at the
+            // same time, but not positive...
+            if (toggleOccured) 
             {
-                urdfInertial.useUrdfData = newValue;
-                urdfInertial.UpdateLinkData();
+                Assert.IsFalse(inertialChanged || anglesChanged || shouldReset);
+                Undo.RecordObject(urdfInertial, "Toggle URDF Overrides");
+                urdfInertial.useUrdfData = !shouldOverride;
             }
+            else if (inertialChanged)
+            {
+                Assert.IsFalse(anglesChanged || shouldReset);
+                Undo.RecordObject(urdfInertial, "Change URDF Inertial Values");
+                urdfInertial.centerOfMass = centerOfMass;
+                urdfInertial.inertiaTensor = inertiaTensor;
+            }
+            else if (anglesChanged)
+            {
+                Assert.IsFalse(shouldReset);
+                Undo.RecordObject(urdfInertial, "Change URDF Inertial tensor rotation");
+                urdfInertial.inertiaTensorRotation.eulerAngles = eulerAngles;
+            }
+            else if (shouldReset)
+            {
+                Undo.RecordObject(urdfInertial, "Reset URDF Inertial Values");
+                urdfInertial.ResetInertial();
+                return;
+            }
+            
+            urdfInertial.UpdateLinkData(toggleOccured);
         }
     }
 }

--- a/com.unity.robotics.urdf-importer/Editor/CustomEditors/UrdfInertialEditor.cs
+++ b/com.unity.robotics.urdf-importer/Editor/CustomEditors/UrdfInertialEditor.cs
@@ -80,7 +80,7 @@ namespace Unity.Robotics.UrdfImporter.Editor
                 return;
             }
             
-            urdfInertial.UpdateLinkData(toggleOccured);
+            urdfInertial.UpdateLinkData(toggleOccured, inertialChanged || anglesChanged);
         }
     }
 }

--- a/com.unity.robotics.urdf-importer/Runtime/RosSharpDefinitions/Link.cs
+++ b/com.unity.robotics.urdf-importer/Runtime/RosSharpDefinitions/Link.cs
@@ -76,6 +76,7 @@ namespace Unity.Robotics.UrdfImporter
             return visuals.ToList();
         }
 
+        [System.Serializable]
         public class Inertial
         {
             public double mass;
@@ -96,6 +97,13 @@ namespace Unity.Robotics.UrdfImporter
                 this.inertia = inertia;
             }
 
+            public Inertial(Inertial other)
+            {
+                mass = other.mass;
+                origin = other.origin;
+                inertia = other.inertia;
+            }
+
             public void WriteToUrdf(XmlWriter writer)
             {
                 writer.WriteStartElement("inertial");
@@ -111,6 +119,7 @@ namespace Unity.Robotics.UrdfImporter
                 writer.WriteEndElement();
             }
 
+            [System.Serializable]
             public class Inertia
             {
                 public double ixx;

--- a/com.unity.robotics.urdf-importer/Runtime/RosSharpDefinitions/Origin.cs
+++ b/com.unity.robotics.urdf-importer/Runtime/RosSharpDefinitions/Origin.cs
@@ -10,13 +10,15 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-*/  
+*/
 
+using System;
 using System.Xml;
 using System.Xml.Linq;
 
 namespace Unity.Robotics.UrdfImporter
 {
+    [Serializable]
     public class Origin
     {
         public double[] Xyz;

--- a/com.unity.robotics.urdf-importer/Runtime/UrdfComponents/UrdfInertial.cs
+++ b/com.unity.robotics.urdf-importer/Runtime/UrdfComponents/UrdfInertial.cs
@@ -43,6 +43,8 @@ namespace Unity.Robotics.UrdfImporter
             if (inertialLink != null)
             {
                 inertialUrdf.m_OriginalValues = inertialLink;
+                // Initialize overrides to URDF values to start
+                inertialUrdf.m_Overrides = inertialLink;
                 inertialUrdf.useUrdfData = true;
             }
             else if (inertialUrdf.TryGetComponent<ArticulationBody>(out var robotLink))
@@ -70,7 +72,7 @@ namespace Unity.Robotics.UrdfImporter
             UpdateLinkData();
         }
 
-        public void UpdateLinkData(bool copyOverrides = false)
+        public void UpdateLinkData(bool copyOverrides = false, bool manualInput = false)
         {
             var articulationBody = GetComponent<ArticulationBody>();
             if (articulationBody == null)
@@ -105,6 +107,10 @@ namespace Unity.Robotics.UrdfImporter
             else if (m_Overrides == null)
             {
                 m_Overrides = ToLinkInertial(articulationBody);
+            }
+            else if (manualInput)
+            {
+                m_Overrides = ToLinkInertial(articulationBody, false);
             }
             AssignUrdfInertiaData(m_Overrides);
         }
@@ -237,32 +243,34 @@ namespace Unity.Robotics.UrdfImporter
             return ToLinkInertial(robotLink);
         }
 
-        Link.Inertial ToLinkInertial(ArticulationBody robotLink)
+        Link.Inertial ToLinkInertial(ArticulationBody robotLink, bool fromArticulation = true)
         {
             var originAngles = inertialAxisRotation.eulerAngles;
+            var com = fromArticulation ? robotLink.centerOfMass : centerOfMass;
             var inertialOrigin = new Origin(
-                robotLink.centerOfMass.Unity2Ros().ToRoundedDoubleArray(), 
-                new double[] { (double)originAngles.x, (double)originAngles.y, (double)originAngles.z });
-            var inertia = ExportInertiaData();
+                com.Unity2Ros().ToRoundedDoubleArray(), 
+                new double[] { originAngles.x, originAngles.y, originAngles.z });
+            var inertia = ExportInertiaData(fromArticulation);
 
             return new Link.Inertial(Math.Round(robotLink.mass, k_RoundDigits), inertialOrigin, inertia);
         }
 
-        private Link.Inertial.Inertia ExportInertiaData()
+        private Link.Inertial.Inertia ExportInertiaData(bool fromArticulation = true)
         {
             var robotLink = GetComponent<ArticulationBody>();
-            
-            Matrix3x3 lamdaMatrix = new Matrix3x3(new[] {
-                robotLink.inertiaTensor[0],
-                robotLink.inertiaTensor[1],
-                robotLink.inertiaTensor[2] });
+            var lambdaMatrix = fromArticulation ? new Matrix3x3(new[]
+            {
+                robotLink.inertiaTensor[0], robotLink.inertiaTensor[1], robotLink.inertiaTensor[2]
+            }) : new Matrix3x3(new[]
+            {
+                inertiaTensor[0], inertiaTensor[1], inertiaTensor[2]
+            });
 
-            Matrix3x3 qMatrix = Quaternion2Matrix(robotLink.inertiaTensorRotation * Quaternion.Inverse(inertialAxisRotation));
-
-            Matrix3x3 qMatrixTransposed = qMatrix.Transpose();
-
-            Matrix3x3 inertiaMatrix = qMatrix * lamdaMatrix * qMatrixTransposed;
-
+            var qMatrix = fromArticulation
+                ? Quaternion2Matrix(robotLink.inertiaTensorRotation * Quaternion.Inverse(inertialAxisRotation))
+                : Quaternion2Matrix(inertiaTensorRotation * Quaternion.Inverse(inertialAxisRotation));
+            var qMatrixTransposed = qMatrix.Transpose();
+            var inertiaMatrix = qMatrix * lambdaMatrix * qMatrixTransposed;
 
             return ToRosCoordinates(ToInertia(inertiaMatrix));
         }

--- a/com.unity.robotics.urdf-importer/Runtime/UrdfComponents/UrdfInertial.cs
+++ b/com.unity.robotics.urdf-importer/Runtime/UrdfComponents/UrdfInertial.cs
@@ -14,91 +14,127 @@ limitations under the License.
 
 using System;
 using UnityEngine;
+using UnityEngine.Assertions;
 
 namespace Unity.Robotics.UrdfImporter
 {
     [RequireComponent(typeof(ArticulationBody))]
     public class UrdfInertial : MonoBehaviour
     {
-        public bool displayInertiaGizmo;
-
+        const int k_RoundDigits = 10;
+        const float k_MinInertia = 1e-6f;
+        const float k_MinMass = 0.1f;
+        
         public bool useUrdfData;
         public Vector3 centerOfMass;
         public Vector3 inertiaTensor;
         public Quaternion inertiaTensorRotation;
         public Quaternion inertialAxisRotation;
 
-        private const int RoundDigits = 10;
-        private const float MinInertia = 1e-6f;
-        private const float minMass = 0.1f;
+        [SerializeField, HideInInspector]
+        Link.Inertial m_OriginalValues;
+        
+        [SerializeField, HideInInspector]
+        Link.Inertial m_Overrides;
 
-        public static void Create(GameObject linkObject, Link.Inertial inertial = null)
+        public static void Create(GameObject linkObject, Link.Inertial inertialLink = null)
         {
-            UrdfInertial urdfInertial = linkObject.AddComponent<UrdfInertial>();
-
-            ArticulationBody robotLink = urdfInertial.GetComponent<ArticulationBody>();
-
-            if (inertial != null)
+            var inertialUrdf = linkObject.AddComponent<UrdfInertial>();
+            if (inertialLink != null)
             {
-                robotLink.mass = ((float)inertial.mass > 0)?((float)inertial.mass):minMass;
-                if (inertial.origin != null) {
-                    
-                    robotLink.centerOfMass = UrdfOrigin.GetPositionFromUrdf(inertial.origin);
-                }
-                else
-                {
-                    robotLink.centerOfMass = Vector3.zero;
-                }
-                urdfInertial.ImportInertiaData(inertial);
-                 
-                urdfInertial.useUrdfData = true;
+                inertialUrdf.m_OriginalValues = inertialLink;
+                inertialUrdf.useUrdfData = true;
             }
+            else if (inertialUrdf.TryGetComponent<ArticulationBody>(out var robotLink))
+            {
+                robotLink.mass = Mathf.Max(robotLink.mass, k_MinMass);
 
-            urdfInertial.displayInertiaGizmo = false;
+                inertialUrdf.m_Overrides = inertialUrdf.ToLinkInertial(robotLink);
+                // NOTE: The first time this is set to true, we'll save the current state of m_Overrides as the default,
+                //       since there is no actual URDF data to default to
+                inertialUrdf.useUrdfData = false;
+            }
+            inertialUrdf.UpdateLinkData();
+        }
+
+        public void ResetInertial()
+        {
+            m_Overrides = m_OriginalValues;
+            AssignUrdfInertiaData(m_Overrides);
         }
 
 #region Runtime
 
-        private void Start()
+        void Start()
         {
             UpdateLinkData();
         }
 
-        public void UpdateLinkData()
+        public void UpdateLinkData(bool copyOverrides = false)
         {
-
-            ArticulationBody robotLink = GetComponent<ArticulationBody>();
-
+            var articulationBody = GetComponent<ArticulationBody>();
+            if (articulationBody == null)
+            {
+                return;
+            }
+            
             if (useUrdfData)
             {
-                robotLink.centerOfMass = centerOfMass;
-                robotLink.inertiaTensor = inertiaTensor;
-                robotLink.inertiaTensorRotation = inertiaTensorRotation * inertialAxisRotation;
+                if (m_OriginalValues == null)
+                {
+                    Debug.LogWarning(
+                        "This instance doesn't have any urdf data stored - " +
+                        "creating some using the current inertial values.");
+                    m_OriginalValues = ToLinkInertial(articulationBody);
+                }
+                Assert.IsNotNull(m_OriginalValues);
+                if (copyOverrides)
+                {
+                    m_Overrides = ToLinkInertial(articulationBody);
+                }
+                AssignUrdfInertiaData(m_OriginalValues);
+                return;
             }
-            else
+            
+            if (copyOverrides)
             {
-                robotLink.ResetCenterOfMass();
-                robotLink.ResetInertiaTensor();
+                m_Overrides ??= new Link.Inertial(m_OriginalValues);
             }
+            // Ensure that when this script is hot-loaded for the first time that this previously non-existent variable
+            // gets some sensible values (by copying them from the current state of the ArticulationBody)
+            else if (m_Overrides == null)
+            {
+                m_Overrides = ToLinkInertial(articulationBody);
+            }
+            AssignUrdfInertiaData(m_Overrides);
         }
 
 #endregion
 
 #region Import
 
-        private void ImportInertiaData(Link.Inertial inertial)
+        void AssignUrdfInertiaData(Link.Inertial linkInertial)
         {
+            Assert.IsNotNull(linkInertial);
+            var robotLink = GetComponent<ArticulationBody>();
+            robotLink.mass = (float)linkInertial.mass > 0 
+                ? (float)linkInertial.mass 
+                : k_MinMass;
+            
+            robotLink.centerOfMass = linkInertial.origin != null 
+                ? UrdfOrigin.GetPositionFromUrdf(linkInertial.origin) 
+                : Vector3.zero;
+            
             Vector3 eigenvalues;
             Vector3[] eigenvectors;
-            Matrix3x3 rotationMatrix = ToMatrix3x3(inertial.inertia);
+            Matrix3x3 rotationMatrix = ToMatrix3x3(linkInertial.inertia);
             rotationMatrix.DiagonalizeRealSymmetric(out eigenvalues, out eigenvectors);
-            ArticulationBody robotLink = GetComponent<ArticulationBody>();
 
             Vector3 inertiaEulerAngles;
 
-            if (inertial.origin != null)
+            if (linkInertial.origin != null)
             {
-                inertiaEulerAngles = UrdfOrigin.GetRotationFromUrdf(inertial.origin);
+                inertiaEulerAngles = UrdfOrigin.GetRotationFromUrdf(linkInertial.origin);
             }
             else
             {
@@ -134,12 +170,12 @@ namespace Unity.Robotics.UrdfImporter
                                                                  (float)inertia.izz });
         }
 
-        private static Vector3 FixMinInertia(Vector3 vector3)
+        static Vector3 FixMinInertia(Vector3 vector3)
         {
-            for (int i = 0; i < 3; i++)
+            for (var i = 0; i < 3; i++)
             {
-                if (vector3[i] < MinInertia)
-                    vector3[i] = MinInertia;
+                if (vector3[i] < k_MinInertia)
+                    vector3[i] = k_MinInertia;
             }
             return vector3;
         }
@@ -187,24 +223,34 @@ namespace Unity.Robotics.UrdfImporter
 #endregion
 
 #region Export
-        public Link.Inertial ExportInertialData() 
+        public Link.Inertial ExportInertialData()
         {
-            ArticulationBody robotLink = GetComponent<ArticulationBody>();
+            var robotLink = GetComponent<ArticulationBody>();
 
             if (robotLink == null)
+            {
+                Debug.LogWarning("No data to export.");
                 return null;
+            }
 
             UpdateLinkData();
-            Vector3 originAngles = inertialAxisRotation.eulerAngles;
-            Origin inertialOrigin = new Origin(robotLink.centerOfMass.Unity2Ros().ToRoundedDoubleArray(), new double[] { (double)originAngles.x, (double)originAngles.y, (double)originAngles.z });
-            Link.Inertial.Inertia inertia = ExportInertiaData();
+            return ToLinkInertial(robotLink);
+        }
 
-            return new Link.Inertial(Math.Round(robotLink.mass, RoundDigits), inertialOrigin, inertia);
+        Link.Inertial ToLinkInertial(ArticulationBody robotLink)
+        {
+            var originAngles = inertialAxisRotation.eulerAngles;
+            var inertialOrigin = new Origin(
+                robotLink.centerOfMass.Unity2Ros().ToRoundedDoubleArray(), 
+                new double[] { (double)originAngles.x, (double)originAngles.y, (double)originAngles.z });
+            var inertia = ExportInertiaData();
+
+            return new Link.Inertial(Math.Round(robotLink.mass, k_RoundDigits), inertialOrigin, inertia);
         }
 
         private Link.Inertial.Inertia ExportInertiaData()
         {
-            ArticulationBody robotLink = GetComponent<ArticulationBody>();
+            var robotLink = GetComponent<ArticulationBody>();
             
             Matrix3x3 lamdaMatrix = new Matrix3x3(new[] {
                 robotLink.inertiaTensor[0],


### PR DESCRIPTION
## Proposed change(s)

A follow-up to #195; fixes setting of the initial values on the UrdfInertial component and maintains changes between Edit and PlayModes by updating Origin to be Serializable, + override value setting bugfix I was running into while testing.

### Types of change(s)

- [x] Bug fix

## Checklist
- [x] Ensured this PR is up-to-date with the `dev` branch
- [x] Created this PR to target the `dev` branch
- [x] Updated the [Changelog](https://github.com/Unity-Technologies/URDF-Importer/blob/dev/com.unity.robotics.urdf-importer/CHANGELOG.md) and described changes in the [Unreleased section](https://github.com/Unity-Technologies/URDF-Importer/blob/dev/com.unity.robotics.urdf-importer/CHANGELOG.md#unreleased)