### PR TITLE
fixed image path in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ URDF Importer allows you to import a robot defined in [URDF](http://wiki.ros.org
 
 3. A window will appear with the Import settings for the Robot. First setting mentions the orientation of the mesh files. The second setting is used to select the algorithm to be used in Collision mesh Decomposition. For more information click [here](https://github.com/Unity-Technologies/Unity-Robotics-Hub/blob/main/tutorials/urdf_importer/urdf_appendix.md#convex-mesh-collider)
 
-<img src = "images~/URDF%20Menu.png" width = 40% height = 40%>
+<img src = "images~/URDF%20Import%20Menu.png" width = 80% height = 80%>
 
 4. Click `Import URDF`
 


### PR DESCRIPTION
## Proposed change(s)

I was working through the documentation and saw that the image path was not defined correctly

### Useful links (GitHub issues, JIRA tickets, forum threads, etc.)

### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [x] Documentation update
- [ ] Other (please describe)

## Testing and Verification

### Test Configuration:

## Checklist
- [x] Ensured this PR is up-to-date with the `dev` branch
- [x] Created this PR to target the `dev` branch
- [x] Followed the style guidelines as described in the [Contribution Guidelines](https://github.com/Unity-Technologies/URDF-Importer/blob/main/CONTRIBUTING.md)
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Increased the [test coverage criteria](https://github.com/Unity-Technologies/URDF-Importer/blob/dev/.yamato/yamato-config.yml#L18) by 3%
- [ ] Updated the [Changelog](https://github.com/Unity-Technologies/URDF-Importer/blob/dev/com.unity.robotics.urdf-importer/CHANGELOG.md) and described changes in the [Unreleased section](https://github.com/Unity-Technologies/URDF-Importer/blob/dev/com.unity.robotics.urdf-importer/CHANGELOG.md#unreleased)
- [ ] Updated the documentation as appropriate

## Other comments